### PR TITLE
19-bidirectional-sc-methods

### DIFF
--- a/R/sc2.R
+++ b/R/sc2.R
@@ -62,7 +62,7 @@ sc2 <- function(ae, wr = FALSE) {
   dat[ , tmp := median(resp), by = list(spid, wllt, logc)]
   
   ## take absolute value for bidirectional fitting.
-  dat[ , c("tmpi", "max_med") := list(.GRP, max(abs(tmp))), by = spid]
+  dat[ , c("tmpi", "max_med","max_tmp") := list(.GRP, max(abs(tmp)), tmp[which.max(abs(tmp))]), by = spid]
   
   ## Initialize coff vector
   coff <- 0
@@ -98,9 +98,9 @@ sc2 <- function(ae, wr = FALSE) {
   
   ## Determine hit-call
   dat[ , hitc := as.integer(max_med >= coff)]
-  
+
   ## set max med back to the tmp value so we conserve directionality.
-  dat[ , max_med := tmp]
+  dat[ , max_med := max_tmp]
 
   ttime <- round(difftime(Sys.time(), stime, units = "sec"), 2)
   ttime <- paste(unclass(ttime), units(ttime))


### PR DESCRIPTION
I set max_med to absolute value so bidirectional data will be fit in single conc.

- all max_median values will now be positive when that was not necessarily the case in the past
- it is assumed bmad/coff will always be positive
- this does not address bidirectional == FALSE

Take a look at your favorite SC dataset and let me know if this is working for you.  I tested on invitrodb_test aeid 890 and it appears to be working.