### PR TITLE
issue-63 remove <br/> from vignette links

### DIFF
--- a/vignettes/Data_processing-Archive_tcpl_v2.Rmd
+++ b/vignettes/Data_processing-Archive_tcpl_v2.Rmd
@@ -7,7 +7,7 @@ output:
     toc: yes
     toc_depth: 4
 vignette: >
-  %\VignetteIndexEntry{tcpl 2.0 <br />Data Processing<br />}
+  %\VignetteIndexEntry{tcpl 2.0 Data Processing}
   %\VignetteEngine{knitr::rmarkdown}
   %\usepackage[utf8]{inputenc}
 ---

--- a/vignettes/Data_processing.Rmd
+++ b/vignettes/Data_processing.Rmd
@@ -7,7 +7,7 @@ output:
     toc: yes
     toc_depth: 4
 vignette: >
-  %\VignetteIndexEntry{tcpl v3.0 <br />Data Processing<br />}
+  %\VignetteIndexEntry{tcpl v3.0 Data Processing}
   %\VignetteEngine{knitr::rmarkdown}
   %\usepackage[utf8]{inputenc}
 ---

--- a/vignettes/Data_retrieval.Rmd
+++ b/vignettes/Data_retrieval.Rmd
@@ -7,7 +7,7 @@ output:
     toc: yes
     toc_depth: 4
 vignette: >
-  %\VignetteIndexEntry{tcpl v3.0 <br />Data Retrieval<br />}
+  %\VignetteIndexEntry{tcpl v3.0 Data Retrieval}
   %\VignetteEngine{knitr::rmarkdown}
   %\usepackage[utf8]{inputenc}
 ---

--- a/vignettes/Introduction_Appendices.Rmd
+++ b/vignettes/Introduction_Appendices.Rmd
@@ -7,7 +7,7 @@ output:
     toc: yes
     toc_depth: 4
 vignette: >
-  %\VignetteIndexEntry{The ToxCast(TM) Analysis Pipeline(tcpl)<br /> An R Package for Processing and Modeling Chemical Screening Data (Version 3.0)<br />}
+  %\VignetteIndexEntry{The ToxCast(TM) Analysis Pipeline(tcpl) An R Package for Processing and Modeling Chemical Screening Data (Version 3.0)}
   %\VignetteEngine{knitr::rmarkdown}
   %\usepackage[utf8]{inputenc}
 ---


### PR DESCRIPTION
Closes #63. The hrefs linking to the vingettes contained <br /> elements which were visible. These changes will remove such elements. You can see this under Documentation > Vignettes at the cran page for tcpl: [https://cran.r-project.org/web/packages/tcpl/index.html](url)