### PR TITLE
32 implemented single concentration bidirectional=false method

### DIFF
--- a/R/sc2_mthds.R
+++ b/R/sc2_mthds.R
@@ -133,8 +133,17 @@ sc2_mthds <- function() {
       
       e1 <- bquote(dat[ , bmad := mad(resp[wllt == "n"], na.rm = TRUE)])
       list(e1)
+      
     },
-     bmad2 = function() {
+    
+    ow_bidirectional_false = function() {
+      
+      e1 <- bquote(dat[ , c("max_med","max_tmp") := list(max(tmp), tmp[which.max(tmp)]), by = spid])
+      list(e1)
+      
+    },
+    
+    bmad2 = function() {
       
       e1 <- bquote(coff <- c(coff, dat[ , unique(bmad)*2]))
       list(e1)


### PR DESCRIPTION
Added method for non bidirectional single conc assays. Tested with the following lines connected to invitrodb_test:

```
tcplMthdClear(lvl = 2, id = 1508, type = "sc")
## 25 is the method id for ow_bidirectional_false()
tcplMthdAssign(lvl = 2, 
               id = 1508, 
               mthd_id = c(25, 2), 
               ordr = 1:2, 
               type = "sc")
sc2(ae=1508)
```

I have not done unit testing for this method.