### PR TITLE
68 fixed v2 vignette bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ tcplLite.Rproj
 inst/doc
 data-raw/db_cred.R
 /revdep/
+/doc/
+/Meta/

--- a/vignettes/Data_processing-Archive_tcpl_v2.Rmd
+++ b/vignettes/Data_processing-Archive_tcpl_v2.Rmd
@@ -186,6 +186,8 @@ tcplRegister(what = "acsn",
 ```
 The data are now ready to be loaded with the <font face="CMTT10"> tcplWriteLvl0 </font> function.
 ```{r eval = TRUE, message = FALSE}
+## Cannot process a concentration value of 0; use .01 as a dummy value
+mcdat$conc[mcdat$conc == 0] <- .01
 tcplWriteLvl0(dat = mcdat, type = "mc")
 
 ```


### PR DESCRIPTION
Changed any concentration values of 0 from the mcdat data to be .01, because of the new constraints on lvl0. This resolves the bug and closes #68.

Building the vignettes created two new top level folders and automatically altered the .gitignore file -- assuming this is fine.