### PR TITLE
52 fix tcplPrepOtpt bug with 0 rows input

### DIFF
--- a/R/tcplLoadUnit.R
+++ b/R/tcplLoadUnit.R
@@ -30,7 +30,7 @@ tcplLoadUnit <- function(aeid) {
       aeid IN (%s);
     "
   
-  qstring <- sprintf(qformat, paste(aeid, collapse = ","))
+  qstring <- sprintf(qformat, paste("\"", aeid, "\"", collapse = ","))
   
   dat <- tcplQuery(query = qstring, db = getOption("TCPL_DB"), tbl=c("assay_component_endpoint"))
   

--- a/R/tcplLoadUnit.R
+++ b/R/tcplLoadUnit.R
@@ -30,7 +30,7 @@ tcplLoadUnit <- function(aeid) {
       aeid IN (%s);
     "
   
-  qstring <- sprintf(qformat, paste("\"", aeid, "\"", collapse = ","))
+  qstring <- sprintf(qformat, paste0("\"", aeid, "\"", collapse = ","))
   
   dat <- tcplQuery(query = qstring, db = getOption("TCPL_DB"), tbl=c("assay_component_endpoint"))
   


### PR DESCRIPTION
Query sent to tcplQuery for loading units had a where statement with empty parentheses when the input had 0 rows, which was invalid for SQL to process. This fix allows for 0 row inputs. Closes #52.

tcplLoadUnit still puts a warning to the output because the "given aeid(s) do not have response units." This looks to be expected behavior though.