### PR TITLE
94 fixed bug with tcplLoadData(lvl=4, addfld=FALSE)

### DIFF
--- a/R/tcplLoadData.R
+++ b/R/tcplLoadData.R
@@ -721,8 +721,8 @@ tcplLoadData <- function(lvl, fld = NULL, val = NULL, type = "mc", add.fld = TRU
       
       if(add.fld) wtest <- FALSE
       wtest <- lvl %in% c(0) | (lvl == 2 & type == "sc")
-      if(!check_tcpl_db_schema() & lvl == 4){
-        wtest <- TRUE
+      if(lvl == 4){
+        if (!check_tcpl_db_schema() || !add.fld) wtest <- TRUE
       }
       
       qformat <- paste(qformat, if (wtest) "WHERE" else "AND")


### PR DESCRIPTION
This bug at first looked like an issue with tcplPrepOtpt but was instead with tcplLoadData. The select statement created for use with tcplQuery when lvl=4 and addfld=F used an AND instead of WHERE. This altered check resolves this bug and closes #94.

The following line now returns the appropriate data rather than returning a SQL syntax error:
`tcplLoadData(lvl = 4, fld = "aeid", val = 2, add.fld = FALSE)`

Calls to tcplLoadData when the level changes or add.fld is true/false for other levels are also still testing successfully.