### PR TITLE
98 duplicate acsn bug resolved

### DIFF
--- a/R/tcplRegister.R
+++ b/R/tcplRegister.R
@@ -41,8 +41,18 @@ tcplRegister <- function(what, flds) {
     flds[ , c(xtra) := NULL]
   }
   
-  tcplAppend(dat = flds, tbl = i[[1]], db = getOption("TCPL_DB"), lvl=what)
-  
-  TRUE
+  ## add try catch here to catch UNIQUE mysql error
+  tryCatch(
+    {
+      tcplAppend(dat = flds, tbl = i[[1]], db = getOption("TCPL_DB"), lvl=what)
+      TRUE
+    },
+    error=function(error) {
+      message(paste(what, "was not inserted into the database:"))
+      message(error)
+      if (grepl("Duplicate entry", error)) message("\nDuplicate values are not permitted; this source may already be registered!")
+      FALSE
+    }
+    )
   
 }

--- a/R/tcplRegister.R
+++ b/R/tcplRegister.R
@@ -41,7 +41,6 @@ tcplRegister <- function(what, flds) {
     flds[ , c(xtra) := NULL]
   }
   
-  ## add try catch here to catch UNIQUE mysql error
   tryCatch(
     {
       tcplAppend(dat = flds, tbl = i[[1]], db = getOption("TCPL_DB"), lvl=what)


### PR DESCRIPTION
Duplicates acsn's have been removed from the assay_component_map table and the acsn column was given the `UNIQUE` constraint.

Added a check within tcplRegister for catching error and created output message if duplicates are attempted to be registered.

```
> tcplRegister(what = "acsn", flds = list(acid = 2938, acsn = "tox21-ror-cho-viability-p1_set1"))
acsn was not inserted into the database:
Duplicate entry 'tox21-ror-cho-viability-p1_set1' for key 'acsn' [1062]
Duplicate values are not permitted; this source may already be registered!
[1] FALSE
```

Closes #98.