### PR TITLE
Resolves resolution bug that caused many more points to be plotted than required

### DIFF
--- a/R/tcplPlot.R
+++ b/R/tcplPlot.R
@@ -262,12 +262,9 @@ tcplPlotlyPlot <- function(dat, lvl = 5){
   # extract range from level 3 data for creating plotting all the functions
   # increase resolution to get smoother curves
   resolution <- 100
-  l3_range <- l3_dat %>%
-    pull(.data$conc) %>%
-    range()
+  x_min_max <- range(l3_dat$conc)
+  x_range <- 10^(seq(from = log10(x_min_max[1]), to = log10(x_min_max[2]), length.out = resolution))
   
-  l3_range <- l3_range * resolution
-  x_range <- floor(l3_range[1]):ceiling(l3_range[2]) / resolution
   
   #check if winning model = none 
   if (!dat$modl == "none"){


### PR DESCRIPTION
updated bug in resolution so the interactive plot actually outputs the number of points specified.  Default is 100

Shaved 3 seconds off of render

library(tcpl)
tcplConf(user='_dataminer', pass='pass', db='prod_internal_invitrodb_v4_1', drvr='MySQL', host='ccte-mysql-res.epa.gov')

library(tictoc)
tic()
tcplPlot(fld = "m5id", val = 1097704, output = "console")
toc()

devtools::load_all()
tcplConf(user='_dataminer', pass='pass', db='prod_internal_invitrodb_v4_1', drvr='MySQL', host='ccte-mysql-res.epa.gov')
tic()
tcplPlot(fld = "m5id", val = 1097704, output = "console")
toc()