### PR TITLE
128 changed export_ready parameter default to FALSE

### DIFF
--- a/R/tcplSubsetChid.R
+++ b/R/tcplSubsetChid.R
@@ -14,7 +14,7 @@
 #' @param flag Integer, the mc6_mthd_id values to go into the flag count, see
 #' details for more information
 #' @param type Character of length 1, the data type, "sc" or "mc"
-#' @param export_ready Boolean, default TRUE, should only export ready 1 values be included in calculation
+#' @param export_ready Boolean, default FALSE, should only export ready 1 values be included in calculation
 #'
 #' @details
 #' \code{tcplSubsetChid} is intended to work with level 5 data that has
@@ -61,7 +61,7 @@
 #' @import data.table
 #' @export
 
-tcplSubsetChid <- function(dat, flag = TRUE, type = "mc", export_ready = TRUE) {
+tcplSubsetChid <- function(dat, flag = TRUE, type = "mc", export_ready = FALSE) {
   ## Variable-binding to pass R CMD Check
   chit <- hitc <- aeid <- casn <- fitc <- fitc.ordr <- m4id <- nflg <- NULL
   chid <- logc <- minc <- NULL

--- a/man/tcplSubsetChid.Rd
+++ b/man/tcplSubsetChid.Rd
@@ -4,7 +4,7 @@
 \alias{tcplSubsetChid}
 \title{Subset level 5 data to a single sample per chemical}
 \usage{
-tcplSubsetChid(dat, flag = TRUE, type = "mc", export_ready = TRUE)
+tcplSubsetChid(dat, flag = TRUE, type = "mc", export_ready = FALSE)
 }
 \arguments{
 \item{dat}{data.table, a data.table with level 5 data}
@@ -14,7 +14,7 @@ details for more information}
 
 \item{type}{Character of length 1, the data type, "sc" or "mc"}
 
-\item{export_ready}{Boolean, default TRUE, should only export ready 1 values be included in calculation}
+\item{export_ready}{Boolean, default FALSE, should only export ready 1 values be included in calculation}
 }
 \value{
 A data.table with a single sample for every given chemical-assay


### PR DESCRIPTION
When working with data that does not include the export_ready column, the default being set to TRUE results in error. By setting the default to FALSE, when using tcplSubsetChid for preparing for release, we will now just have to add export_ready = TRUE as an option.