### PR TITLE
5 add padilla phase iii sc2 mthds and fix spid character string call

### DIFF
--- a/R/sc2.R
+++ b/R/sc2.R
@@ -62,7 +62,7 @@ sc2 <- function(ae, wr = FALSE) {
   dat[ , tmp := median(resp), by = list(spid, wllt, logc)]
   
   ## take absolute value for bidirectional fitting.
-  dat[ , c("tmpi", "max_med","max_tmp") := list(.GRP, max(abs(tmp)), tmp[which.max(abs(tmp))]), by = spid]
+  dat[ , c("tmpi", "max_med","max_tmp") := c(.GRP, max(abs(tmp)), tmp[which.max(abs(tmp))]), by = spid]
   
   ## Initialize coff vector
   coff <- 0

--- a/R/sc2.R
+++ b/R/sc2.R
@@ -62,7 +62,7 @@ sc2 <- function(ae, wr = FALSE) {
   dat[ , tmp := median(resp), by = list(spid, wllt, logc)]
   
   ## take absolute value for bidirectional fitting.
-  dat[ , c("tmpi", "max_med","max_tmp") := c(.GRP, max(abs(tmp)), tmp[which.max(abs(tmp))]), by = spid]
+  dat[ , c("tmpi", "max_med","max_tmp") := list(.GRP, max(abs(tmp)), tmp[which.max(abs(tmp))]), by = c("spid")]
   
   ## Initialize coff vector
   coff <- 0

--- a/R/sc2_mthds.R
+++ b/R/sc2_mthds.R
@@ -61,6 +61,7 @@
 #' \subsection{Percent of Control Methods}{
 #'  \describe{
 #'   \item{pc0.88}{Add a cutoff value of 0.88. Typically for percent of control data.}
+#'   \item{pc16}{Add a cutoff value of 16. Typically for percent of control data.}
 #'   \item{pc20}{Add a cutoff value of 20. Typically for percent of control data.}
 #'   \item{pc25}{Add a cutoff value of 25. Typically for percent of control data.}
 #'   \item{pc30}{Add a cutoff value of 30. Typically for percent of control data.}
@@ -232,8 +233,14 @@ sc2_mthds <- function() {
       e1 <- bquote(coff <- c(coff, dat[ , unique(bmad)*1.5]))
       list(e1)
       
+     },
+    
+    pc16 = function() {
+      
+      e1 <- bquote(coff <- c(coff, 16))
+      list(e1)
+      
     }
-
   )
 }
 


### PR DESCRIPTION
Added sc2 method for coff=pc16 and fixed the following character string bug. Padilla sc data processed successfully!

tcplRun(id = 2942, type = "sc", slvl = 1L, elvl = 2L)
Loaded L0 ACID2942 (2544 rows; 10.68 secs)
Processed L1 ACID2942 (284 rows; 14.51 secs)
Writing level 1 data for 1 ids...
Completed delete cascade for 1 ids (2.63 secs)
Writing level 1 complete. (24.09 secs)
Loaded L1 AEID3213 (284 rows; 4.56 secs)
Error in FUN(X[[i]], ...) : 'what' must be a function or character string