### PR TITLE
60 remove subset by wllt in mc4.R

### DIFF
--- a/R/mc4.R
+++ b/R/mc4.R
@@ -50,7 +50,6 @@ mc4 <- function(ae, wr = FALSE) {
 
   ## Load level 3 data
   dat <- tcplLoadData(lvl = 3L, type = "mc", fld = "aeid", val = ae)
-  dat <- dat[wllt %in% c("t", "c", "o", "n","z")]
 
   ## Check if any level 3 data was loaded
   if (nrow(dat) == 0) {


### PR DESCRIPTION
Removed line which subsets level 3 data in mc4 processing by well types [https://github.com/USEPA/CompTox-ToxCast-tcpl/blob/main/R/mc4.R#L53](url)

Closes #60.