### PR TITLE
folded osd calculation into bmad methods

### DIFF
--- a/R/mc4_mthds.R
+++ b/R/mc4_mthds.R
@@ -64,21 +64,16 @@ mc4_mthds <- function() {
     bmad.aeid.lowconc.twells = function() {
       
       e1 <- bquote(dat[ , bmad := mad(resp[cndx %in% 1:2 & wllt == "t"], na.rm = TRUE)])
-      list(e1)
+      e2 <- bquote(dat[ , osd := sd(resp[cndx %in% 1:2 & wllt == "t"], na.rm = TRUE)])
+      list(e1, e2)
       
     },
     
     bmad.aeid.lowconc.nwells = function() {
       
       e1 <- bquote(dat[ , bmad := mad(resp[wllt == "n"], na.rm = TRUE)])
-      list(e1)
-      
-    },
-    
-    onesd.aeid.lowconc.twells = function() {
-      
-      e1 <- bquote(dat[ , osd := sd(resp[cndx %in% 1:2 & wllt == "t"], na.rm = TRUE)])
-      list(e1)
+      e2 <- bquote(dat[ , osd := sd(resp[wllt == "n"], na.rm = TRUE)])
+      list(e1, e2)
       
     },
     


### PR DESCRIPTION
Now instead of applying a different method for bmad and onesd you pick a single method and the associated n or t wells are used to calculate each of the measurments.