### PR TITLE
163 create single direction sc methods

### DIFF
--- a/R/sc2.R
+++ b/R/sc2.R
@@ -78,8 +78,11 @@ sc2 <- function(ae, wr = FALSE) {
   
   ## Extract methods that need to overwrite bmad
   ms_overwrite <- ms[grepl("ow_",mthd),]
+  ## Extract methods that need to overwrite hitc
+  ms_hitc <- ms[grepl("hitc_",mthd),]
   ## ignore any other methods
   ms <- ms[!grepl("ow_",mthd),]
+  ms <- ms[!grepl("hitc_",mthd),]
   
   ## Apply bmad overwrite methods first if needed
   if (nrow(ms_overwrite) > 0) {
@@ -98,6 +101,13 @@ sc2 <- function(ae, wr = FALSE) {
   
   ## Determine hit-call
   dat[ , hitc := as.integer(max_med >= coff)]
+  
+  ## Apply bmad overwrite methods first if needed
+  if (nrow(ms_hitc) > 0) {
+    exprs <- lapply(mthd_funcs[ms_hitc$mthd], do.call, args = list())
+    fenv <- environment()
+    invisible(rapply(exprs, eval, envir = fenv))
+  }
 
   ## set max med back to the tmp value so we conserve directionality.
   dat[ , max_med := max_tmp]

--- a/R/sc2.R
+++ b/R/sc2.R
@@ -84,11 +84,12 @@ sc2 <- function(ae, wr = FALSE) {
   ms <- ms[!grepl("ow_",mthd),]
   ms <- ms[!grepl("hitc_",mthd),]
   
-  ## Apply bmad overwrite methods first if needed
+  
+  ## Apply bmad/max_med overwrite methods first if needed
   if (nrow(ms_overwrite) > 0) {
-  exprs <- lapply(mthd_funcs[ms_overwrite$mthd], do.call, args = list())
-  fenv <- environment()
-  invisible(rapply(exprs, eval, envir = fenv))
+    exprs <- lapply(mthd_funcs[ms_overwrite$mthd], do.call, args = list())
+    fenv <- environment()
+    invisible(rapply(exprs, eval, envir = fenv))
   }
   
   ## Apply cutoff methods
@@ -102,15 +103,16 @@ sc2 <- function(ae, wr = FALSE) {
   ## Determine hit-call
   dat[ , hitc := as.integer(max_med >= coff)]
   
-  ## Apply bmad overwrite methods first if needed
+  ## set max med back to the tmp value so we conserve directionality.
+  dat[ , max_med := max_tmp]
+  
+  ## Apply hitc overwrite methods if needed
   if (nrow(ms_hitc) > 0) {
     exprs <- lapply(mthd_funcs[ms_hitc$mthd], do.call, args = list())
     fenv <- environment()
     invisible(rapply(exprs, eval, envir = fenv))
   }
 
-  ## set max med back to the tmp value so we conserve directionality.
-  dat[ , max_med := max_tmp]
 
   ttime <- round(difftime(Sys.time(), stime, units = "sec"), 2)
   ttime <- paste(unclass(ttime), units(ttime))

--- a/R/sc2_mthds.R
+++ b/R/sc2_mthds.R
@@ -194,9 +194,30 @@ sc2_mthds <- function() {
       
     },
     
-    ow_bidirectional_false = function() {
+    ow_bidirectional_loss = function() {
+      
+      e1 <- bquote(dat[ , c("max_med","max_tmp") := list(abs(min(tmp)), tmp[which.min(tmp)]), by = spid])
+      list(e1)
+      
+    },
+    
+    ow_bidirectional_gain = function() {
       
       e1 <- bquote(dat[ , c("max_med","max_tmp") := list(max(tmp), tmp[which.max(tmp)]), by = spid])
+      list(e1)
+      
+    },
+    
+    hitc_bidirectional_loss = function() {
+      
+      e1 <- bquote(dat$hitc[dat$max_med > 0] <- dat$hitc[dat$max_med > 0] * -1)
+      list(e1)
+      
+    },
+    
+    hitc_bidirectional_gain = function() {
+      
+      e1 <- bquote(dat$hitc[dat$max_med < 0] <- dat$hitc[dat$max_med < 0] * -1)
       list(e1)
       
     },


### PR DESCRIPTION
Changed name of ow_bidirectional_false to ow_bidirectional_gain. Added ow_bidirectional_loss. _gain is max_med to be set to maximum positive, _loss is max_med is set to maximum negative (true minimum). 

Added hitc_bidirectional_gain and _loss to multiply hitcall by -1 if its max_med is in the biologically irrelevant direction. Multiplying by -1 to keep consistent with mc5 ow methods, but definitely not opposed to just setting to 0 here instead.

I don't like this two-(four) method solution where you would have to set 2 methods in a given desired direction. However, I didn't want to alter sc2 to allow for a single method solution for each direction. If editing sc2 to allow just one method each is encouraged, then I'll happily improve that.

This closes #163.