### PR TITLE
196 overwrite osd during hitcalling

### DIFF
--- a/R/mc5.R
+++ b/R/mc5.R
@@ -107,12 +107,12 @@ mc5 <- function(ae, wr = FALSE) {
   ## Determine final cutoff
   dat[ , coff := max(coff)]
   
-  browser()
+
   ## Check to see if we are using the v3 schema
   # currently can only use one coff
   if (check_tcpl_db_schema()) {
     cutoff <- max(dat$coff)
-    
+
     # before hitcalling overwrite osd value
     if(overwrite_osd){
       exprs <- lapply(mthd_funcs[ms_osd_coff_bmr$mthd], do.call, args = list())

--- a/R/mc5.R
+++ b/R/mc5.R
@@ -81,6 +81,14 @@ mc5 <- function(ae, wr = FALSE) {
     loec.mthd = TRUE
     ms <- ms[!mthd=='loec.coff']
   }
+  
+  #special case where osd needs to be overwritten
+  if ('osd_coff_bmr' %in% ms$mthd) {
+    overwrite_osd <- TRUE
+    ms_osd_coff_bmr = ms[mthd=='osd_coff_bmr']
+    ms <- ms[!mthd=='loec.coff']
+  }
+
   ## Extract methods that need to overwrite hitc and hit_val
   ms_overwrite <- ms[grepl("ow_",mthd),]
   ## Extract methods that don't overwrite
@@ -104,6 +112,14 @@ mc5 <- function(ae, wr = FALSE) {
   # currently can only use one coff
   if (check_tcpl_db_schema()) {
     cutoff <- max(dat$coff)
+    
+    # before hitcalling overwrite osd value
+    if(overwrite_osd){
+      exprs <- lapply(mthd_funcs[ms_osd_coff_bmr$mthd], do.call, args = list())
+      fenv <- environment()
+      invisible(rapply(exprs, eval, envir = fenv))
+    }
+    
     # if we're using v3 schema we want to tcplfit2
     dat <- tcplHit2(dat, coff = cutoff)
   } else {

--- a/R/mc5.R
+++ b/R/mc5.R
@@ -99,6 +99,7 @@ mc5 <- function(ae, wr = FALSE) {
   ## Determine final cutoff
   dat[ , coff := max(coff)]
   
+  browser()
   ## Check to see if we are using the v3 schema
   # currently can only use one coff
   if (check_tcpl_db_schema()) {

--- a/R/mc5.R
+++ b/R/mc5.R
@@ -86,7 +86,7 @@ mc5 <- function(ae, wr = FALSE) {
   if ('osd_coff_bmr' %in% ms$mthd) {
     overwrite_osd <- TRUE
     ms_osd_coff_bmr = ms[mthd=='osd_coff_bmr']
-    ms <- ms[!mthd=='loec.coff']
+    ms <- ms[!mthd=='osd_coff_bmr']
   }
 
   ## Extract methods that need to overwrite hitc and hit_val

--- a/R/mc5.R
+++ b/R/mc5.R
@@ -103,15 +103,6 @@ mc5 <- function(ae, wr = FALSE) {
   # currently can only use one coff
   if (check_tcpl_db_schema()) {
     cutoff <- max(dat$coff)
-    #can remove this once loading of data is working correctly
-    dat <- tcplQuery(paste0("SELECT  
-    `mc4`.`m4id`,    `mc4`.`aeid`,    `mc4`.`spid`,    `mc4`.`bmad`,    `mc4`.`resp_max`,    `mc4`.`resp_min`,
-    `mc4`.`max_mean`,    `mc4`.`max_mean_conc`,    `mc4`.`min_mean`,    `mc4`.`min_mean_conc`,
-    `mc4`.`max_med`,    `mc4`.`max_med_conc`,    `mc4`.`min_med`,    `mc4`.`min_med_conc`,    
-    `mc4`.`max_med_diff`,    `mc4`.`max_med_diff_conc`,    `mc4`.`conc_max`,    `mc4`.`conc_min`,    `mc4`.`nconc`,
-    `mc4`.`npts`,    `mc4`.`nrep`,    `mc4`.`nmed_gtbl_pos`,    `mc4`.`nmed_gtbl_neg`,
-    `mc4`.`tmpi`,	  `mc4_param`.`model`,    `mc4_param`.`model_param`,    `mc4_param`.`model_val`
-    FROM mc4 inner join mc4_param on mc4.m4id = mc4_param.m4id where mc4.aeid = ",ae,";"))
     # if we're using v3 schema we want to tcplfit2
     dat <- tcplHit2(dat, coff = cutoff)
   } else {

--- a/R/mc5_mthds.R
+++ b/R/mc5_mthds.R
@@ -333,6 +333,16 @@ mc5_mthds <- function(ae) {
 	  list(e1, e2, e3, e4)
 	  
 	}
+	
+	,
+	
+	ow_osd_coff_bmr = function() {
+	  
+	  # set the osd param so that bmr == coff
+	  e1 <- bquote(dat[ , osd := coff/1.349 ])
+	  list(e1)
+	  
+	}
 
   )
 }

--- a/R/mc5_mthds.R
+++ b/R/mc5_mthds.R
@@ -339,7 +339,7 @@ mc5_mthds <- function(ae) {
 	osd_coff_bmr = function() {
 	  
 	  # set the osd param so that bmr == coff
-	  e1 <- bquote(dat[ , osd := coff/1.349 ])
+	  e1 <- bquote(dat[ , all_onesd := coff/1.349 ])
 	  list(e1)
 	  
 	}

--- a/R/mc5_mthds.R
+++ b/R/mc5_mthds.R
@@ -336,7 +336,7 @@ mc5_mthds <- function(ae) {
 	
 	,
 	
-	ow_osd_coff_bmr = function() {
+	osd_coff_bmr = function() {
 	  
 	  # set the osd param so that bmr == coff
 	  e1 <- bquote(dat[ , osd := coff/1.349 ])


### PR DESCRIPTION
Method was created for level 5.  

Could not be assigned ow_ method because ow_ methods only apply after hitcalling.  This one was a bit weird because it needed to be applied after the coff but before hitcalling.

Also integrated new tcplloaddata into mc5.R 

Pipelined 2771 as a test case and successfully wrote to db