### PR TITLE
207 solve mutate error, added errfun to params

### DIFF
--- a/R/tcplFit2.R
+++ b/R/tcplFit2.R
@@ -71,7 +71,7 @@ tcplHit2 <- function(mc4, coff) {
   params  <-conc  <-bmed  <-onesd  <-df  <-aeid  <- NULL
   fit_method  <-hitcall  <-cutoff  <-top_over_cutoff  <-bmd  <-hit_val <- NULL
 
-  long_mc4 <- mc4 |> tidyr::pivot_longer(cols = matches("cnst|hill|gnls|poly1|poly2|pow|exp2|exp3|exp4|exp5|all"), names_to = "model", values_to = "model_val") |> tidyr::separate_wider_delim(col = "model",delim = "_", names = c("model","model_param"), too_many = "merge")
+  long_mc4 <- mc4 |> tidyr::pivot_longer(cols = matches("cnst|hill|gnls|poly1|poly2|pow|exp2|exp3|exp4|exp5|all|errfun"), names_to = "model", values_to = "model_val") |> tidyr::separate_wider_delim(col = "model",delim = "_", names = c("model","model_param"), too_many = "merge")
   
   nested_mc4 <- long_mc4 %>%
     filter(model != "all") %>%
@@ -173,7 +173,8 @@ tcplFit2_unnest <- function(output) {
     lst <- lapply(res[[m]], function(x){ if(length(x) < 1) { x <- NA }; x })
     test <- rbind(test, data.frame(model = m, model_param = names(lst), model_val = unlist(lst), stringsAsFactors = FALSE, row.names = NULL))
   }
-  test
+  # include error function and return
+  rbind(test, list(model = "errfun", model_param = output$errfun, model_val = NA))
 }
 
 
@@ -183,6 +184,10 @@ tcplFit2_unnest <- function(output) {
 #'
 #' @return a list of fitting parameters that can be consumed by tcplfit2
 tcplFit2_nest <- function(dat) {
+  # get errfun and filter it out
+  errfun <- filter(dat, model == "errfun")$model_param
+  dat <- filter(dat, model != "errfun")
+  
   # renest
   modelnames <- unique(dat$model)
   for (m in modelnames) {
@@ -207,7 +212,7 @@ tcplFit2_nest <- function(dat) {
   out1 <- c(
     mget(modelnames),
     list(modelnames = modelnames),
-    errfun = "dt4"
+    errfun = errfun
   )
 }
 

--- a/R/tcplFit2.R
+++ b/R/tcplFit2.R
@@ -206,7 +206,8 @@ tcplFit2_nest <- function(dat) {
 
   out1 <- c(
     mget(modelnames),
-    list(modelnames = modelnames)
+    list(modelnames = modelnames),
+    errfun = "dt4"
   )
 }
 

--- a/R/tcplFit2.R
+++ b/R/tcplFit2.R
@@ -174,7 +174,8 @@ tcplFit2_unnest <- function(output) {
     test <- rbind(test, data.frame(model = m, model_param = names(lst), model_val = unlist(lst), stringsAsFactors = FALSE, row.names = NULL))
   }
   # include error function and return
-  rbind(test, list(model = "errfun", model_param = output$errfun, model_val = NA))
+  errfun <- if (is.null(output$errfun)) "dt4" else output$errfun
+  rbind(test, list(model = "errfun", model_param = errfun, model_val = NA))
 }
 
 


### PR DESCRIPTION
I'll start off this PR by saying I don't necessarily think this is the best way to solve this issue; this may warrant further discussion, especially with those more familiar with recent tcplfit2 changes regarding `errfun`.

This is what we know from #207 and my debugging steps:
* the fail was caused within the call to the tcpl function tcplHit2, where I followed the failure to line 231 within tcplhit2_core
`row <- as.data.frame(c(identifiers, mget(name.list)), stringsAsFactors = FALSE)`
* this "mutate()" error _**only**_ occurred when processing using the _'dev'_ version of tcplFit2
  * this function in tcplFit2 has been updated several times since _'dev'_ was last merged with _'master'_
  * the only other bits of code that affect this line of code are the `identifiers` and `name.list` variables
    * `identifiers` has not changed its functionality
    * the only change with `name.list` was the addition of the `errfun` name

I noticed in the case of this error, `errfun` was `NULL` and which was being pulled from `params` by line 81 
`errfun = params[["errfun"]]`. When I manually set errfun, there was no longer an error. From here, I decided that my approach would be to include an `"errfun"` list element in `params` in the call from tcplHit2, which is the line of code I added here in this PR (`"dt4"` is what I saw around tcplFit2 docs as the default). 

This change does allow for successful processing but I am unsure that it is the correct solution. Should this actually be something that is handled within tcplFit2, to not require `"errfun"` within params, and instead set `"dt4"` as a default if it is `NULL`? Is there something else I am possibly missing here?

Closes #207.