### PR TITLE
220 update mc6 methods to use model_type, update descs, remove no.med.single.dir.gt.3bmad

### DIFF
--- a/R/mc6_mthds.R
+++ b/R/mc6_mthds.R
@@ -150,13 +150,16 @@ mc6_mthds <- function() {
     
     singlept.hit.high = function(mthd) {
       
-      flag <- "Only highest conc above baseline, active"
+      flag <- "Active with only highest conc above baseline"
       out  <- c("m5id", "m4id", "aeid", "mc6_mthd_id", 
                 "flag")
       init <- bquote(list(.(mthd), .(flag), FALSE))
       e1 <- bquote(ft[ , .(c(out[4:5], "test")) := .(init)])
       e2 <- bquote(ft[ , lstc := max_med_diff_conc == conc_max])
-      e3 <- bquote(ft[ , test := (nmed_gtbl_pos == 1 | nmed_gtbl_neg == 1) & hitc >= 0.9 & lstc])
+      e3 <- bquote(ft[ , test := ((nmed_gtbl_pos == 1 & model_type == 2 & top >= 0) |
+                                  (nmed_gtbl_neg == 1 & model_type == 2 & top <= 0) | 
+                                  (nmed_gtbl_pos == 1 & model_type == 3) | 
+                                  (nmed_gtbl_neg == 1 & model_type == 4)) & hitc >= 0.9 & lstc])
       e4 <- bquote(f[[.(mthd)]] <- ft[which(test), .SD, .SDcols = .(out)])
       cr <- c("mc6_mthd_id", "flag", "test", "lstc")
       e5 <- bquote(ft[ , .(cr) := NULL])
@@ -166,13 +169,16 @@ mc6_mthds <- function() {
     
     singlept.hit.mid = function(mthd) {
       
-      flag <- "Only one conc above baseline, active"
+      flag <- "Active with one conc (not highest) above baseline"
       out  <- c("m5id", "m4id", "aeid", "mc6_mthd_id", 
                 "flag")
       init <- bquote(list(.(mthd), .(flag), FALSE))
       e1 <- bquote(ft[ , .(c(out[4:5], "test")) := .(init)])
       e2 <- bquote(ft[ , lstc := max_med_diff_conc == conc_max])
-      e3 <- bquote(ft[ , test := (nmed_gtbl_pos == 1 | nmed_gtbl_neg == 1) & hitc >= 0.9 & !lstc])
+      e3 <- bquote(ft[ , test := ((nmed_gtbl_pos == 1 & model_type == 2 & top >= 0) |
+                                  (nmed_gtbl_neg == 1 & model_type == 2 & top <= 0) | 
+                                  (nmed_gtbl_pos == 1 & model_type == 3) | 
+                                  (nmed_gtbl_neg == 1 & model_type == 4)) & hitc >= 0.9 & !lstc])
       e4 <- bquote(f[[.(mthd)]] <- ft[which(test), .SD, .SDcols = .(out)])
       cr <- c("mc6_mthd_id", "flag", "test", "lstc")
       e5 <- bquote(ft[ , .(cr) := NULL])
@@ -182,12 +188,15 @@ mc6_mthds <- function() {
     
     multipoint.neg = function(mthd) {
       
-      flag <- "Multiple points above baseline, inactive"
+      flag <- "Inactive with multiple concs above baseline"
       out  <- c("m5id", "m4id", "aeid", "mc6_mthd_id", 
                 "flag")
       init <- bquote(list(.(mthd), .(flag), FALSE))
       e1 <- bquote(ft[ , .(c(out[4:5], "test")) := .(init)])
-      e2 <- bquote(ft[ , test := (nmed_gtbl_pos > 1 | nmed_gtbl_neg > 1) & hitc < 0.9 & hitc >= 0])
+      e2 <- bquote(ft[ , test := ((nmed_gtbl_pos > 1 & model_type == 2 & top >= 0) |
+                                  (nmed_gtbl_neg > 1 & model_type == 2 & top <= 0) | 
+                                  (nmed_gtbl_pos > 1 & model_type == 3) | 
+                                  (nmed_gtbl_neg > 1 & model_type == 4)) & hitc < 0.9 & hitc >= 0])
       e3 <- bquote(f[[.(mthd)]] <- ft[which(test), .SD, .SDcols = .(out)])
       cr <- c("mc6_mthd_id", "flag", "test")
       e4 <- bquote(ft[ , .(cr) := NULL])
@@ -330,25 +339,10 @@ mc6_mthds <- function() {
                 "flag")
       init <- bquote(list(.(mthd), .(flag), FALSE))
       e1 <- bquote(ft[ , .(c(out[4:5], "test")) := .(init)])
-      e2 <- bquote(ft[ , test := nmed_gtbl_pos == 0 & nmed_gtbl_neg == 0])
-      e3 <- bquote(f[[.(mthd)]] <- ft[which(test), .SD, .SDcols = .(out)])
-      cr <- c("mc6_mthd_id", "flag", "test")
-      e4 <- bquote(ft[ , .(cr) := NULL])
-      list(e1, e2, e3, e4)
-      
-    },
-    
-    no.med.single.dir.gt.3bmad = function(mthd) {
-      
-      flag <- "No median responses > 3*bmad in intended signal direction"
-      out  <- c("m5id", "m4id", "aeid", "mc6_mthd_id", 
-                "flag")
-      init <- bquote(list(.(mthd), .(flag), FALSE))
-      e1 <- bquote(ft[ , .(c(out[4:5], "test")) := .(init)])
-      e2 <- bquote(ft[ , test := (hitc > 0 & top > 0 & nmed_gtbl_pos == 0) | 
-                                 (hitc < 0 & top > 0 & nmed_gtbl_neg == 0) | 
-                                 (hitc > 0 & top < 0 & nmed_gtbl_neg == 0) | 
-                                 (hitc < 0 & top < 0 & nmed_gtbl_pos == 0)])
+      e2 <- bquote(ft[ , test := (model_type == 2 & top > 0 & nmed_gtbl_pos == 0) | 
+                                 (model_type == 2 & top < 0 & nmed_gtbl_neg == 0) | 
+                                 (model_type == 3 & nmed_gtbl_pos == 0) | 
+                                 (model_type == 4 & nmed_gtbl_neg == 0)])
       e3 <- bquote(f[[.(mthd)]] <- ft[which(test), .SD, .SDcols = .(out)])
       cr <- c("mc6_mthd_id", "flag", "test")
       e4 <- bquote(ft[ , .(cr) := NULL])

--- a/R/mc6_mthds.R
+++ b/R/mc6_mthds.R
@@ -150,7 +150,7 @@ mc6_mthds <- function() {
     
     singlept.hit.high = function(mthd) {
       
-      flag <- "Active with only highest conc above baseline"
+      flag <- "Active with only highest conc above baseline (3*bmad)"
       out  <- c("m5id", "m4id", "aeid", "mc6_mthd_id", 
                 "flag")
       init <- bquote(list(.(mthd), .(flag), FALSE))
@@ -169,7 +169,7 @@ mc6_mthds <- function() {
     
     singlept.hit.mid = function(mthd) {
       
-      flag <- "Active with one conc (not highest) above baseline"
+      flag <- "Active with one conc (not highest) above baseline (3*bmad)"
       out  <- c("m5id", "m4id", "aeid", "mc6_mthd_id", 
                 "flag")
       init <- bquote(list(.(mthd), .(flag), FALSE))
@@ -188,7 +188,7 @@ mc6_mthds <- function() {
     
     multipoint.neg = function(mthd) {
       
-      flag <- "Inactive with multiple concs above baseline"
+      flag <- "Inactive with multiple concs above baseline (3*bmad)"
       out  <- c("m5id", "m4id", "aeid", "mc6_mthd_id", 
                 "flag")
       init <- bquote(list(.(mthd), .(flag), FALSE))
@@ -334,7 +334,7 @@ mc6_mthds <- function() {
     
     no.med.gt.3bmad = function(mthd) {
       
-      flag <- "No median responses > 3*bmad"
+      flag <- "No median responses above baseline (3*bmad)"
       out  <- c("m5id", "m4id", "aeid", "mc6_mthd_id", 
                 "flag")
       init <- bquote(list(.(mthd), .(flag), FALSE))


### PR DESCRIPTION
Made updates and tested/reprocessed level 6 with aeid 2524 (same from email chain) for which here are the plots which contain the flags. I added no.med.gt.3bmad because it was not already assigned.
[aeid2524newflags.pdf](https://github.com/USEPA/CompTox-ToxCast-tcpl/files/14798599/aeid2524newflags.pdf)

Since I removed no.med.single.dir.gt.3bmad (mc6_mthd_id = 21) there are 1198 aeids with that assigned which should now be reassigned to no.med.gt.3bmad (mc6_mthd_id = 20). 

invitrodb will have to have all of level 6 completely reprocessed and no.med.single.dir.gt.3bmad (mc6_mthd_id = 21) needs to be removed from the mc6_mthds table.

Closes #220.