### PR TITLE
216 backwards compatibility checks fixes

### DIFF
--- a/R/tcplMakeAeidMultiPlts.R
+++ b/R/tcplMakeAeidMultiPlts.R
@@ -26,6 +26,8 @@
 #' @importFrom grDevices graphics.off pdf
 #' @export 
 tcplMakeAeidMultiPlts <- function (aeid, lvl = 4L, fname = NULL, odir = getwd(), clib = NULL, hitc.all = TRUE) {
+  if (check_tcpl_db_schema()) stop("This function is no longer supported in this
+                                   version of invitrodb. Consider tcplPlot() instead.")
   spid <- m4id <- NULL
   on.exit(graphics.off())
   if (length(aeid) > 1) 

--- a/R/tcplMakeAeidPlts.R
+++ b/R/tcplMakeAeidPlts.R
@@ -52,6 +52,9 @@ tcplMakeAeidPlts <- function(aeid, compare=F, lvl = 4L, fname = NULL, odir = get
   ## Variable-binding to pass R CMD Check
   spid <- m4id <- NULL
   
+  if (check_tcpl_db_schema()) stop("This function is no longer supported in this
+                                   version of invitrodb. Consider tcplPlot() instead.")
+  
   on.exit(graphics.off())
   
   if (length(aeid) > 2) stop("'aeid' must be of length 1 or 2.")

--- a/R/tcplMakeChidMultiPlts.R
+++ b/R/tcplMakeChidMultiPlts.R
@@ -26,6 +26,8 @@
 #' @importFrom grDevices graphics.off pdf
 #' @export 
 tcplMakeChidMultiPlts <- function (chid, lvl = 4L, fname = NULL, odir = getwd(), clib = NULL, hitc.all = TRUE) {
+  if (check_tcpl_db_schema()) stop("This function is no longer supported in this
+                                   version of invitrodb. Consider tcplPlot() instead.")
   spid <- m4id <- NULL
   on.exit(graphics.off())
   if (length(chid) > 1) 

--- a/R/tcplMultiplot.R
+++ b/R/tcplMultiplot.R
@@ -32,6 +32,9 @@ tcplMultiplot <- function (dat, agg, flg = NULL, boot = NULL, browse = FALSE, hi
   chid <- chnm <- spid <- aenm <- aeid <- m4id <- fitc <- fval <- modl <- hitc <- NULL
   flgo <- mc6_mthd_id <- J <- NULL
   
+  if (check_tcpl_db_schema()) stop("This function is no longer supported in this
+                                   version of invitrodb. Consider tcplPlot() instead.")
+  
   if (!is.null(flg) & !"m5id" %in% names(dat)) {
     stop("Must supply level 5 data with a non-null 'flg' input.")
   }

--- a/R/tcplPlot.R
+++ b/R/tcplPlot.R
@@ -189,6 +189,7 @@ tcplPlot <- function(type = "mc", fld = "m4id", val = NULL, compare.val = NULL, 
     }
     
     # unlog concs
+    if (!("conc" %in% colnames(agg))) agg <- mutate(agg, conc = 10^logc)
     if (type == "mc") {
       conc_resp_table <- agg %>% group_by(m4id) %>% summarise(conc = list(conc), resp = list(resp)) %>% as.data.table()
       dat <- dat[conc_resp_table, on = "m4id"]

--- a/R/tcplPlotFitc.R
+++ b/R/tcplPlotFitc.R
@@ -36,6 +36,9 @@ tcplPlotFitc <- function(fitc = NULL, main = NULL, fitc_sub = NULL) {
   r <- g <- N <- edge <- plt <- leaf <- parent_fitc <- xloc <- yloc <- NULL
   name <- J <- NULL
   
+  if (check_tcpl_db_schema()) stop("This function is no longer supported in this
+                                   version of invitrodb. Consider tcplPlot() instead.")
+  
   if (!is.null(fitc)) {
     
     vals <- data.table(fitc = fitc)[ , .N, by = fitc]

--- a/R/tcplPlotFits.R
+++ b/R/tcplPlotFits.R
@@ -80,6 +80,9 @@ tcplPlotFits <- function(dat, agg, flg = NULL, boot = NULL, ordr.fitc = FALSE,
   chid <- chnm <- spid <- aenm <- aeid <- m4id <- fitc <- fval <- NULL
   flgo <- mc6_mthd_id <- J <- NULL
   
+  if (check_tcpl_db_schema()) stop("This function is no longer supported in this
+                                   version of invitrodb. Consider tcplPlot() instead.")
+  
   if (!is.null(flg) & !"m5id" %in% names(dat)) {
     stop("Must supply level 5 data with a non-null 'flg' input.")
   }

--- a/R/tcplPlotM4ID.R
+++ b/R/tcplPlotM4ID.R
@@ -46,6 +46,9 @@
 
 tcplPlotM4ID <- function(m4id, lvl = 4L) {
   
+  if (check_tcpl_db_schema()) stop("This function is no longer supported in this
+                                   version of invitrodb. Consider tcplPlot() instead.")
+  
   if (length(lvl) > 1 | !lvl %in% 4:7) stop("invalid lvl input.")
   
   prs <- list(type = "mc", fld = "m4id", val = m4id)

--- a/R/tcplPlotPlate.R
+++ b/R/tcplPlotPlate.R
@@ -59,6 +59,9 @@ tcplPlotPlate <- function(dat, apid, id = NULL, quant = c(0.001, 0.999)) {
   wllq <- aid <- wllt <- cndx <- nwll <- rown <- rowi <- coln <- NULL
   coli <- anm <- NULL
   
+  if (check_tcpl_db_schema()) stop("This function is no longer supported in this
+                                   version of invitrodb. Consider tcplPlot() instead.")
+  
   if (length(apid) != 1) stop("'apid' must be of length 1.")
   ap <- apid
   

--- a/R/tcplSubsetChid.R
+++ b/R/tcplSubsetChid.R
@@ -152,9 +152,10 @@ tcplSubsetChid <- function(dat, flag = TRUE, type = "mc", export_ready = FALSE) 
     setkey(dat, "s2id")
     dat <- dat[dat1]
 
-    setkeyv(dat, c("aeid", "chid", "logc"))
-    dat[, minc := min(logc), by = list(aeid, chid)]
-    dat <- dat[logc == minc]
+    concvar <- if ("conc" %in% colnames(dat)) "conc" else "logc"
+    setkeyv(dat, c("aeid", "chid", concvar))
+    dat[, minc := min(get(concvar)), by = list(aeid, chid)]
+    dat <- dat[get(concvar) == minc]
     dat <- unique(dat[, c("spid", "chid", "casn", "chnm", "dsstox_substance_id", "code", "aeid", "aenm", "s2id", "bmad", "max_med", "hitc", "coff", "resp_unit")])
     setkeyv(dat, c("aeid", "chid", "max_med"))
 


### PR DESCRIPTION
Closes #216. Added some checks to old plotting functions and logc/conc backwards compatibility into tcplPlot and tcplSubsetChid. 

The tcplSubsetChid code change is the same that is currently in the varmat pull request, so following a merge of one of the two the other may need a merge conflict resolved.