### PR TITLE
Standalone Plotting (and comparison between versions of invitrodb)

### DIFF
--- a/R/tcplPlot.R
+++ b/R/tcplPlot.R
@@ -107,7 +107,7 @@ tcplPlot <- function(dat = NULL, type = "mc", fld = "m4id", val = NULL, compare.
     }
     
     # set yrange from tcplPlotUtils.R
-    yrange <- tcplPlotSetYRange(dat,yuniform,yrange)
+    yrange <- tcplPlotSetYRange(dat,yuniform,yrange,type)
     
     # if you have compare data, join it back to main datatable
     if(!is.null(compare.dat)){

--- a/R/tcplPlot.R
+++ b/R/tcplPlot.R
@@ -72,6 +72,9 @@ tcplPlot <- function(dat = NULL, type = "mc", fld = "m4id", val = NULL, compare.
     # check if user supplied data.  If not, load from db connection
     if(is.null(dat)){
       dat <- tcplPlotLoadData(lvl = lvl, fld = fld, val = val, type = type,flags = flags, compare = FALSE) #code defined in tcplPlotUtils.R
+    } else {
+      # if user supplies dat we still need to add compare indicator
+      dat <- dat[,compare := FALSE]
     }
     if(!is.null(compare.val)){
       # check that val and compare.val are the same length 

--- a/R/tcplPlot.R
+++ b/R/tcplPlot.R
@@ -84,37 +84,33 @@ tcplPlot <- function(dat = NULL, type = "mc", fld = "m4id", val = NULL, compare.
       if (nrow(compare.dat) == 0) stop("No compare data for fld/val provided")
     }
     
-    
-    # check for null bmd in dat table
-    if (verbose){
-      dat <- dat[is.null(dat$bmd), bmd:=NA]
-    }
-    
-    
-  
     # join with given val/compare.val if lengths don't match
     if (!is.null(compare.val) && nrow(dat) + nrow(compare.dat) != length(val) + length(compare.val)) {
       val_dt <- as.data.table(val)
-      colnames(val_dt) <- "m4id"
+      join_condition <- c("m4id","s2id")[c("m4id","s2id") %in% colnames(dat)]
+      colnames(val_dt) <- join_condition
       compare.val_dt <- as.data.table(compare.val)
-      colnames(compare.val_dt) <- "m4id"
-      dat <- val_dt %>% inner_join(dat, by = "m4id")
-      compare.dat <- compare.val_dt %>% inner_join(compare.dat, by = "m4id")
+      colnames(compare.val_dt) <- join_condition
+      dat <- val_dt %>% inner_join(dat, by = join_condition)
+      compare.dat <- compare.val_dt %>% inner_join(compare.dat, by = join_condition)
       dat <- rbind(dat, compare.dat, fill = TRUE)
     } else {
-      # preserve user-given order
-      setorder(dat, order)
-      
       # if you have compare data, join it back to main datatable
       if(!is.null(compare.dat)){
         dat <- rbind(dat,compare.dat, fill = TRUE)
       }
+      
+      # preserve user-given order
+      setorder(dat, order)
     }
     
     # set yrange from tcplPlotUtils.R
     yrange <- tcplPlotSetYRange(dat,yuniform,yrange,type)
     
-    
+    # check for null bmd in dat table
+    if (verbose){
+      dat <- dat[is.null(dat$bmd), bmd:=NA]
+    }
     
     
     # assign nrow = ncol = 1 for output="pdf" and multi=FALSE to plot one plot per page

--- a/R/tcplPlot.R
+++ b/R/tcplPlot.R
@@ -78,7 +78,7 @@ tcplPlot <- function(dat = NULL, type = "mc", fld = "m4id", val = NULL, compare.
     }
     if(!is.null(compare.val)){
       # check that val and compare.val are the same length 
-      if (!is.null(compare.val) && length(unlist(val)) != length(unlist(compare.val))) stop("'compare.val' must be of equal length to 'val'")
+      if (!is.null(compare.val) && nrow(dat) != length(unlist(compare.val))) stop("'compare.val' must be of equal length to 'val'")
       
       compare.dat <- tcplPlotLoadData(lvl = lvl, fld = fld, val = compare.val, type = type,flags = flags, compare = TRUE) #code defined in tcplPlotUtils.R
       if (nrow(compare.dat) == 0) stop("No compare data for fld/val provided")

--- a/R/tcplPlot.R
+++ b/R/tcplPlot.R
@@ -84,12 +84,11 @@ tcplPlot <- function(dat = NULL, type = "mc", fld = "m4id", val = NULL, compare.
     # join with given val/compare.val if lengths don't match
     if (!is.null(compare.val) && nrow(dat) + nrow(compare.dat) != length(val) + length(compare.val)) {
       val_dt <- as.data.table(val)
-      join_condition <- c("m4id","s2id")[c("m4id","s2id") %in% colnames(dat)]
-      colnames(val_dt) <- join_condition
+      colnames(val_dt) <- fld
       compare.val_dt <- as.data.table(compare.val)
-      colnames(compare.val_dt) <- join_condition
-      dat <- val_dt %>% inner_join(dat, by = join_condition)
-      compare.dat <- compare.val_dt %>% inner_join(compare.dat, by = join_condition)
+      colnames(compare.val_dt) <- fld
+      dat <- val_dt %>% inner_join(dat, by = fld)
+      compare.dat <- compare.val_dt %>% inner_join(compare.dat, by = fld)
     } 
     
     # if you have compare data, join it back to main datatable

--- a/R/tcplPlot.R
+++ b/R/tcplPlot.R
@@ -104,15 +104,17 @@ tcplPlot <- function(dat = NULL, type = "mc", fld = "m4id", val = NULL, compare.
     } else {
       # preserve user-given order
       setorder(dat, order)
+      
+      # if you have compare data, join it back to main datatable
+      if(!is.null(compare.dat)){
+        dat <- rbind(dat,compare.dat, fill = TRUE)
+      }
     }
     
     # set yrange from tcplPlotUtils.R
     yrange <- tcplPlotSetYRange(dat,yuniform,yrange,type)
     
-    # if you have compare data, join it back to main datatable
-    if(!is.null(compare.dat)){
-    dat <- rbind(dat,compare.dat, fill = TRUE)
-    }
+    
     
     
     # assign nrow = ncol = 1 for output="pdf" and multi=FALSE to plot one plot per page

--- a/R/tcplPlot.R
+++ b/R/tcplPlot.R
@@ -62,14 +62,10 @@ tcplPlot <- function(dat = NULL, type = "mc", fld = "m4id", val = NULL, compare.
   #variable binding
   conc_unit <- bmd <- resp <- compare.dat <- NULL
   
-  # set lvl based on type
-  lvl <- 5
-  if (type == "sc") {
-    lvl <- 2
-    if (flags == TRUE) {
-      warning("'flags' was set to TRUE - no flags exist for plotting single concentration")
-    }
-  }
+  # Validate vars based on some assumed properties
+  validated_vars <- tcplPlotValidate(type = type,flags = flags,output = output,multi = multi,verbose = verbose)
+  # take list of validated vars and add them to the function's environment
+  list2env(validated_vars, envir = environment())
 
   # check_tcpl_db_schema is a user-defined function found in v3_schema_functions.R file
   if (check_tcpl_db_schema() | !is.null(dat)) {

--- a/R/tcplPlot.R
+++ b/R/tcplPlot.R
@@ -77,9 +77,6 @@ tcplPlot <- function(dat = NULL, type = "mc", fld = "m4id", val = NULL, compare.
       dat <- dat[,compare := FALSE]
     }
     if(!is.null(compare.val)){
-      # check that val and compare.val are the same length 
-      if (!is.null(compare.val) && nrow(dat) != length(unlist(compare.val))) stop("'compare.val' must be of equal length to 'val'")
-      
       compare.dat <- tcplPlotLoadData(lvl = lvl, fld = fld, val = compare.val, type = type,flags = flags, compare = TRUE) #code defined in tcplPlotUtils.R
       if (nrow(compare.dat) == 0) stop("No compare data for fld/val provided")
     }
@@ -93,16 +90,17 @@ tcplPlot <- function(dat = NULL, type = "mc", fld = "m4id", val = NULL, compare.
       colnames(compare.val_dt) <- join_condition
       dat <- val_dt %>% inner_join(dat, by = join_condition)
       compare.dat <- compare.val_dt %>% inner_join(compare.dat, by = join_condition)
-      dat <- rbind(dat, compare.dat, fill = TRUE)
-    } else {
-      # if you have compare data, join it back to main datatable
-      if(!is.null(compare.dat)){
-        dat <- rbind(dat,compare.dat, fill = TRUE)
-      }
-      
-      # preserve user-given order
-      setorder(dat, order)
+    } 
+    
+    # if you have compare data, join it back to main datatable
+    if(!is.null(compare.dat)){
+      # check that val and compare.val are the same length 
+      if (nrow(dat) != nrow(compare.dat)) stop("'compare.val' must be of equal length to 'val'")
+      dat <- rbind(dat,compare.dat, fill = TRUE)
     }
+    
+    # preserve user-given order
+    setorder(dat, order)
     
     # set yrange from tcplPlotUtils.R
     yrange <- tcplPlotSetYRange(dat,yuniform,yrange,type)
@@ -111,7 +109,6 @@ tcplPlot <- function(dat = NULL, type = "mc", fld = "m4id", val = NULL, compare.
     if (verbose){
       dat <- dat[is.null(dat$bmd), bmd:=NA]
     }
-    
     
     # assign nrow = ncol = 1 for output="pdf" and multi=FALSE to plot one plot per page
     if(nrow(dat) > 1 && output == "pdf" && multi == FALSE) {

--- a/R/tcplPlot.R
+++ b/R/tcplPlot.R
@@ -93,7 +93,7 @@ tcplPlot <- function(dat = NULL, type = "mc", fld = "m4id", val = NULL, compare.
     
     # if you have compare data, join it back to main datatable
     if(!is.null(compare.dat)){
-      # check that val and compare.val are the same length 
+      # check that dat and compare.dat are the same length 
       if (nrow(dat) != nrow(compare.dat)) stop("'compare.val' must be of equal length to 'val'")
       dat <- rbind(dat,compare.dat, fill = TRUE)
     }

--- a/R/tcplPlot.R
+++ b/R/tcplPlot.R
@@ -131,7 +131,7 @@ tcplPlot <- function(dat = NULL, type = "mc", fld = "m4id", val = NULL, compare.
     
     
     
-    if (nrow(dat) == 1) {
+    if (nrow(dat[compare == FALSE]) == 1) {
       # plot single graph
       # this needs to be fixed to be more succinct about users selected option
       ifelse(output[1] == "console",

--- a/R/tcplPlotUtils.R
+++ b/R/tcplPlotUtils.R
@@ -1,0 +1,209 @@
+tcplPlotLoadData <- function(lvl,fld, val, type,flags, compare = FALSE){
+  
+  # check that input combination is unique
+  input <- tcplLoadData(lvl = lvl, fld = fld, val = val, type = type)
+  if (nrow(input) == 0) stop("No data for fld/val provided")
+  
+
+  mcLoadDat <- function(m4id = NULL,flags) {
+    l4 <- tcplLoadData(lvl = 4, fld = "m4id", val = m4id, add.fld = T)
+    dat <- l4[input, on = "m4id"]
+    if (flags == TRUE) {
+      l6 <- tcplLoadData(lvl=6, fld='m4id', val=m4id, type='mc')
+      if (nrow(l6) > 0) {
+        l6 <- l6[ , .( flag = paste(flag, collapse=";\n")), by = m4id]
+        no_flags <- setdiff(m4id, l6$m4id)
+        if (length(no_flags) > 0) {
+          l6 <- rbindlist(list(l6, data.table("m4id" = no_flags, "flag" = "None")))
+        } 
+      } else {
+        l6 <- data.table(m4id, "flag" = "None")
+      }
+      dat <- dat[l6, on = "m4id"]
+    }
+    tcplPrepOtpt(dat)
+  }
+  
+  scLoadDat <- function(s2id = NULL) {
+    tcplPrepOtpt(input)
+  }
+  
+  # load dat
+  if (type == "mc") {
+    dat <- mcLoadDat(input$m4id,flags = flags)[, compare := compare]
+  } else { # type == 'sc' 
+    dat <- scLoadDat(input$s2id)[, compare := compare]
+  }
+  
+  # order dataframe and add index
+  dat <- dat[order(match(get(fld[1]), val))]
+  dat$order <- 1:nrow(dat)
+  
+  # add normalized data type for y axis
+  ndt <- tcplLoadAeid(fld = "aeid", val = dat$aeid, add.fld = "normalized_data_type")
+  dat <- dat[ndt, on = "aeid"]
+  
+  if("m4id" %in% colnames(dat)){
+    agg <- tcplLoadData(lvl = "agg", fld = "m4id", val = dat$m4id)
+  }
+  if("s2id" %in% colnames(dat)){
+    agg <- tcplLoadData(lvl = "agg", fld = "s2id", val = dat$s2id, type = "sc")
+  }
+  # unlog concs
+  if (!("conc" %in% colnames(agg))) agg <- mutate(agg, conc = 10^logc)
+  
+  #determine if we're single conc or multiconc based on dat
+  join_condition <- c("m4id","s2id")[c("m4id","s2id") %in% colnames(dat)]
+  conc_resp_table <- agg %>% group_by(.data[[join_condition]]) %>% summarise(conc = list(conc), resp = list(resp)) %>% as.data.table()
+  dat <- dat[conc_resp_table, on = join_condition]
+  
+  # correct concentration unit label for x-axis
+  dat <- dat[is.na(conc_unit), conc_unit:="\u03BCM"]
+  dat <- dat[conc_unit=="uM", conc_unit:="\u03BCM"]
+  dat <- dat[conc_unit=="mg/l", conc_unit:="mg/L"]
+  
+  
+  dat
+}
+
+tcplPlotSetYRange <- function(dat,yuniform,yrange){
+  #validate yrange
+  if (length(yrange) != 2) {
+    stop("'yrange' must be of length 2")
+  }
+  
+  # set range
+  if (yuniform == TRUE && identical(yrange, c(NA,NA))) {
+    min <- min(dat$resp_min, unlist(dat$resp))
+    max <- max(dat$resp_max, unlist(dat$resp))
+    if (type == "mc") {
+      # any bidirectional models contained in dat, cutoff both ways
+      if (2 %in% dat$model_type) {
+        cutoffs <- dat[model_type == 2]$coff
+        min <- min(min, cutoffs, cutoffs * -1)
+        max <- max(max, cutoffs, cutoffs * -1)
+      }
+      # any gain models contained in dat, cutoff only positive
+      if (3 %in% dat$model_type) {
+        cutoffs <- dat[model_type == 3]$coff
+        min <- min(min, cutoffs)
+        max <- max(max, cutoffs)
+      }
+      # any loss models contained in dat, cutoff only negative
+      if (4 %in% dat$model_type) {
+        cutoffs <- dat[model_type == 4]$coff
+        min <- min(min, cutoffs * -1)
+        max <- max(max, cutoffs * -1)
+      }
+    } else {
+      min <- min(min, dat$coff, dat$coff * -1)
+      max <- max(max, dat$coff, dat$coff * -1)
+    }
+    yrange = c(min, max)
+  }
+  
+  yrange
+}
+  
+  
+  tcplPlotValidate <- function(dat){
+    
+    # default assign multi=TRUE for output="pdf" 
+    if (output == "pdf" && is.null(multi)) {
+      multi <- TRUE
+    }
+    # forced assign multi=FALSE for output = c("console","png","jpg","svg","tiff"), verbose=FALSE for output="console"
+    if (output !="pdf") {
+      multi <- FALSE
+      if(output =="console"){
+        verbose <- FALSE
+      }
+    }
+
+    
+  }
+  
+  
+  tcplLegacyPlot <- function(){
+    if (length(output) > 1) output <- output[1]
+    
+    prs <- list(type = "mc", fld = fld, val = val)
+    
+    if (lvl == 4L) dat <- do.call(tcplLoadData, args = c(lvl = 4L, prs))
+    if (lvl >= 5L) dat <- do.call(tcplLoadData, args = c(lvl = 5L, prs))
+    if (lvl >= 6L) {
+      flg <- do.call(tcplLoadData, args = c(lvl = 6L, prs))
+    } else {
+      flg <- NULL
+    }
+    if (lvl == 7L) {
+      boot <- do.call(tcplLoadData, args = c(lvl = 7L, prs))
+    } else {
+      boot <- NULL
+    }
+    
+    if (nrow(dat) == 0) stop("No data for fld/val provided")
+    
+    agg <- do.call(tcplLoadData, args = c(lvl = "agg", prs))
+    
+    if (nrow(dat) == 1 & output == "console") {
+      tcplPlotFits(dat = dat, agg = agg, flg = flg, boot = boot)
+    }
+    if (nrow(dat) > 1 & output == "console") stop("More than 1 concentration series returned for given field/val combination.  Set output to pdf or reduce the number of curves to 1. Current number of curves: ", nrow(dat))
+    
+    
+    if (is.null(by)) {
+      if (output == "pdf" & !multi) {
+        graphics.off()
+        pdf(
+          file = file.path(
+            getwd(),
+            paste0(fileprefix, ".", output)
+          ),
+          height = 6,
+          width = 10,
+          pointsize = 10
+        )
+        tcplPlotFits(dat = dat, agg = agg, flg = flg, boot = boot)
+        graphics.off()
+      }
+      # plotting if using multiplot function
+      hitc.all <- TRUE
+      if (multi) {
+        graphics.off()
+        pdf(file = file.path(getwd(), paste0(fileprefix, ".", output)), height = 10, width = 6, pointsize = 10)
+        par(mfrow = c(3, 2))
+        tcplMultiplot(dat = dat, agg = agg, flg = flg, boot = boot, hitc.all = hitc.all)
+        graphics.off()
+      }
+    } else {
+      if (!by %in% names(dat)) stop("grouping variable unavailable.")
+      subset <- unlist(unique(dat[, by, with = FALSE]))
+      for (s in subset) {
+        if (output == "pdf" & !multi) {
+          graphics.off()
+          pdf(
+            file = file.path(
+              getwd(),
+              paste0(fileprefix, "_", by, "_", s, ".", output)
+            ),
+            height = 6,
+            width = 10,
+            pointsize = 10
+          )
+          tcplPlotFits(dat = dat[get(by) == s], agg = agg, flg = flg, boot = boot)
+          graphics.off()
+        }
+        # plotting if using multiplot function
+        hitc.all <- TRUE
+        if (multi) {
+          graphics.off()
+          pdf(file = file.path(getwd(), paste0(fileprefix, "_", by, "_", s, ".", output)), height = 10, width = 6, pointsize = 10)
+          par(mfrow = c(3, 2))
+          tcplMultiplot(dat = dat[get(by) == s], agg = agg, flg = flg, boot = boot, hitc.all = hitc.all)
+          graphics.off()
+        }
+      }
+    }
+  }
+  

--- a/R/tcplPlotUtils.R
+++ b/R/tcplPlotUtils.R
@@ -35,10 +35,6 @@ tcplPlotLoadData <- function(lvl,fld, val, type,flags, compare = FALSE){
     dat <- scLoadDat(input$s2id)[, compare := compare]
   }
   
-  # order dataframe and add index
-  dat <- dat[order(match(get(fld[1]), val))]
-  dat$order <- 1:nrow(dat)
-  
   # add normalized data type for y axis
   ndt <- tcplLoadAeid(fld = "aeid", val = dat$aeid, add.fld = "normalized_data_type")
   dat <- dat[ndt, on = "aeid"]
@@ -61,7 +57,10 @@ tcplPlotLoadData <- function(lvl,fld, val, type,flags, compare = FALSE){
   dat <- dat[is.na(conc_unit), conc_unit:="\u03BCM"]
   dat <- dat[conc_unit=="uM", conc_unit:="\u03BCM"]
   dat <- dat[conc_unit=="mg/l", conc_unit:="mg/L"]
-  
+
+  # set order to given order
+  dat <- dat[order(match(get(fld[1]), val))]
+  dat$order <- 1:nrow(dat)
   
   dat
 }

--- a/R/tcplPlotUtils.R
+++ b/R/tcplPlotUtils.R
@@ -59,7 +59,7 @@ tcplPlotLoadData <- function(lvl,fld, val, type,flags, compare = FALSE){
   dat <- dat[conc_unit=="mg/l", conc_unit:="mg/L"]
 
   # set order to given order
-  dat <- dat[order(match(get(fld[1]), val))]
+  dat <- dat[order(match(get(fld[1]), val[[1]]))]
   dat$order <- 1:nrow(dat)
   
   dat

--- a/R/tcplPlotUtils.R
+++ b/R/tcplPlotUtils.R
@@ -105,7 +105,16 @@ tcplPlotSetYRange <- function(dat,yuniform,yrange){
 }
   
   
-  tcplPlotValidate <- function(dat){
+  tcplPlotValidate <- function(type,flags,output,multi,verbose){
+    
+    # set lvl based on type
+    lvl <- 5
+    if (type == "sc") {
+      lvl <- 2
+      if (flags == TRUE) {
+        warning("'flags' was set to TRUE - no flags exist for plotting single concentration")
+      }
+    }
     
     # default assign multi=TRUE for output="pdf" 
     if (output == "pdf" && is.null(multi)) {
@@ -118,8 +127,9 @@ tcplPlotSetYRange <- function(dat,yuniform,yrange){
         verbose <- FALSE
       }
     }
-
     
+    list(type = type,flags = flags,output = output,multi = multi,verbose = verbose)
+
   }
   
   

--- a/R/tcplPlotUtils.R
+++ b/R/tcplPlotUtils.R
@@ -128,7 +128,7 @@ tcplPlotSetYRange <- function(dat,yuniform,yrange,type){
       }
     }
     
-    list(type = type,flags = flags,output = output,multi = multi,verbose = verbose)
+    list(lvl = lvl,type = type,flags = flags,output = output,multi = multi,verbose = verbose)
 
   }
   

--- a/R/tcplPlotUtils.R
+++ b/R/tcplPlotUtils.R
@@ -65,7 +65,7 @@ tcplPlotLoadData <- function(lvl,fld, val, type,flags, compare = FALSE){
   dat
 }
 
-tcplPlotSetYRange <- function(dat,yuniform,yrange){
+tcplPlotSetYRange <- function(dat,yuniform,yrange,type){
   #validate yrange
   if (length(yrange) != 2) {
     stop("'yrange' must be of length 2")


### PR DESCRIPTION
First pass for standalone plotting introduces tcplLoadPlotData and tcplLoadUtils  See code below for example plotting all IA from Madison's analysis.

closes #121 

library(readr)
library(dplyr)
filepath <- "L:/Lab/Toxcast_Data/toxcast_data/misc/invitrodb_v4_2_qc/inspect_invitrodb_v4_2_flips_16APR2024.csv"
comparison_dataset <- read_csv(filepath)

plot_testing <- comparison_dataset |> filter(flip_dir == "IA")
plot_testing <- plot_testing |> arrange(aenm)

devtools::load_all()
tcplConf(user='_dataminer', pass='pass', db='prod_internal_invitrodb_v4_1', drvr='MySQL', host='ccte-mysql-res.epa.gov')
dat_TEST <- tcplPlotLoadData(lvl = 5, fld = "m5id", val = plot_testing$old_m5id, type = "mc",flags = TRUE, compare = FALSE)

tcplConf(user='_dataminer', pass='pass', db='invitrodb', drvr='MySQL', host='ccte-mysql-res.epa.gov')

n <- nrow(dat_TEST)

tcplPlot(dat = head(dat_TEST,n),
         type = "mc",
         fld = "m5id",
         val = head(dat_TEST$m5id,n),
         compare.val = head(plot_testing$new_m5id,n),
         multi = TRUE,
         verbose = TRUE,
         output = "pdf",
         flags = TRUE)