### PR TITLE
243 update blineshift and related methods

### DIFF
--- a/R/blineShift.R
+++ b/R/blineShift.R
@@ -37,7 +37,7 @@ blineShift <- function(resp, conc, wndw) {
 
   low <- 1:max(ceiling(nconc/4), 2)
   rsub <- resp[which(conc %in% uconc[low])]
-  csub <- conc[which(conc %in% uconc[low])]
+  csub <- log10(conc[which(conc %in% uconc[low])])
   low_med <- median(rsub)
   m <- lm(rsub ~ csub)$coefficients["csub"]
   if (is.na(m)) m <- 0

--- a/R/mc3_mthds.R
+++ b/R/mc3_mthds.R
@@ -532,10 +532,10 @@ mc3_mthds <- function() {
     resp.blineshift.3bmad.repi = function(aeids) {
       
       e1 <- bquote(dat[J(.(aeids)), 
-                       wndw := mad(resp[cndx %in% 1:2 & wllt == "t"], 
+                       wndw := mad(resp[cndx %in% 1:2], 
                                    na.rm = TRUE) * 3,
                        by = aeid])
-      e2 <- bquote(dat[aeid %in% .(aeids) & wllt %in% c("t", "c", "o"), 
+      e2 <- bquote(dat[aeid %in% .(aeids), 
                        resp := blineShift(resp, conc, wndw), 
                        by = list(aeid, spid, repi)])
       e3 <- bquote(dat[ , wndw := NULL])
@@ -545,7 +545,7 @@ mc3_mthds <- function() {
     
     resp.blineshift.50.repi = function(aeids) {
       
-      e1 <- bquote(dat[aeid %in% .(aeids) & wllt %in% c("t", "c", "o"), 
+      e1 <- bquote(dat[aeid %in% .(aeids), 
                        resp := blineShift(resp, conc, wndw = 50), 
                        by = list(aeid, spid, repi)])
       list(e1)
@@ -555,10 +555,10 @@ mc3_mthds <- function() {
     resp.blineshift.3bmad.spid = function(aeids) {
       
       e1 <- bquote(dat[J(.(aeids)), 
-                       wndw := mad(resp[cndx %in% 1:2 & wllt == "t"], 
+                       wndw := mad(resp[cndx %in% 1:2], 
                                    na.rm = TRUE) * 3,
                        by = aeid])
-      e2 <- bquote(dat[aeid %in% .(aeids) & wllt %in% c("t", "c", "o"), 
+      e2 <- bquote(dat[aeid %in% .(aeids), 
                        resp := blineShift(resp, conc, wndw), 
                        by = list(aeid, spid)])
       e3 <- bquote(dat[ , wndw := NULL])
@@ -568,7 +568,7 @@ mc3_mthds <- function() {
     
     resp.blineshift.50.spid = function(aeids) {
       
-      e1 <- bquote(dat[aeid %in% .(aeids) & wllt %in% c("t", "c", "o"), 
+      e1 <- bquote(dat[aeid %in% .(aeids), 
                        resp := blineShift(resp, conc, wndw = 50), 
                        by = list(aeid, spid)])
       list(e1)


### PR DESCRIPTION
The logc->conc change affected the baseline shifts. This PR logs the concentrations when calculating the shift to resolve the issue. It also removes wllt subsets that are done in the mc3 blineshift methods. Closes #243.