### PR TITLE
233 expand ccd r integration into tcpl load funcs

### DIFF
--- a/R/tcplLoadAcid.R
+++ b/R/tcplLoadAcid.R
@@ -7,6 +7,14 @@
 #' @export
 
 tcplLoadAcid <- function(fld = NULL, val = NULL, add.fld = NULL) {
+  
+  if (getOption("TCPL_DRVR") == "API") {
+    dat <- tcplQueryAPI(resource = "assay", fld = fld, val = val, return_flds = c("acid", "assay_component_name", add.fld))
+    setnames(dat, "assay_component_name", "acnm")
+    setorder(dat, "acid")
+    return(unique(dat, by = c(fld, "acid", "acnm")))
+  }
+  
   tbl = c("assay_component", "assay_component_map", "assay")
   out <- c("assay_component.acid", 
            "assay_component.assay_component_name")

--- a/R/tcplLoadAeid.R
+++ b/R/tcplLoadAeid.R
@@ -11,7 +11,8 @@ tcplLoadAeid <- function(fld = NULL, val = NULL, add.fld = NULL) {
   if (getOption("TCPL_DRVR") == "API") {
     dat <- tcplQueryAPI(resource = "assay", fld = fld, val = val, return_flds = c("aeid", "assay_component_endpoint_name", add.fld))
     setnames(dat, "assay_component_endpoint_name", "aenm")
-    return(dat)
+    setorder(dat, "aeid")
+    return(unique(dat, by = c(fld, "aeid", "aenm")))
   }
   
   tbl = c("assay_component_endpoint", "assay", "assay_component")

--- a/R/tcplLoadAid.R
+++ b/R/tcplLoadAid.R
@@ -7,6 +7,14 @@
 #' @export
 
 tcplLoadAid <- function(fld = NULL, val = NULL, add.fld = NULL) {
+  
+  if (getOption("TCPL_DRVR") == "API") {
+    dat <- tcplQueryAPI(resource = "assay", fld = fld, val = val, return_flds = c("aid", "assay_name", add.fld))
+    setnames(dat, "assay_name", "anm")
+    setorder(dat, "aid")
+    return(unique(dat, by = c(fld, "aid", "anm")))
+  }
+  
   tbl=c("assay")
   out <- c("assay.aid", 
            "assay.assay_name")

--- a/R/tcplLoadAsid.R
+++ b/R/tcplLoadAsid.R
@@ -7,6 +7,14 @@
 #' @export
 
 tcplLoadAsid <- function(fld = NULL, val = NULL, add.fld = NULL) {
+  
+  if (getOption("TCPL_DRVR") == "API") {
+    dat <- tcplQueryAPI(resource = "assay", fld = fld, val = val, return_flds = c("asid", "assay_source_name", add.fld))
+    setnames(dat, "assay_source_name", "asnm")
+    setorder(dat, "asid")
+    return(unique(dat, by = c(fld, "asid", "asnm")))
+  }
+  
   tbl = "assay_source"
   out <- c("assay_source.asid", 
            "assay_source.assay_source_name")

--- a/R/tcplLoadChem.R
+++ b/R/tcplLoadChem.R
@@ -54,24 +54,32 @@
 
 tcplLoadChem <- function(field = NULL, val = NULL, exact = TRUE,
                          include.spid = TRUE) {
-  tbl <- c("chemical", "sample")
-  ## Variable-binding to pass R CMD Check
-  code <- casn <- chid <- chnm <- dsstox_substance_id <- NULL
   
-  if (!is.null(field)) {
-    vfield <- c("chid", "spid", "chnm", "casn", "code", "chem.only","dsstox_substance_id")
-    if (!field %in% vfield) stop("Invalid 'field' value.")
-  }
-  
-  
-  qstring <- .ChemQ(field = field, val = val, exact = exact)
-  
-  dat <- tcplQuery(query = qstring, tbl=tbl)
-  dat <- as.data.table(dat)
-
-  if (nrow(dat) == 0) {
-    warning("The given ", field,"(s) are not in the tcpl database.")
-    return(dat[])
+  if (getOption("TCPL_DRVR") == "API") {
+    if (tolower(field) != "spid") stop("When drvr option is set to 'API', only 'spid' is a valid 'field' value.")
+    if (!exact) exact <- TRUE
+    dat <- tcplQueryAPI(resource = "data", fld = "spid", val = val, return_flds = c("spid", "chid", "casn", "chnm", "dsstox_substance_id"))
+    setorder(dat, "spid")
+  } else {
+    tbl <- c("chemical", "sample")
+    ## Variable-binding to pass R CMD Check
+    code <- casn <- chid <- chnm <- dsstox_substance_id <- NULL
+    
+    if (!is.null(field)) {
+      vfield <- c("chid", "spid", "chnm", "casn", "code", "chem.only","dsstox_substance_id")
+      if (!field %in% vfield) stop("Invalid 'field' value.")
+    }
+    
+    
+    qstring <- .ChemQ(field = field, val = val, exact = exact)
+    
+    dat <- tcplQuery(query = qstring, tbl=tbl)
+    dat <- as.data.table(dat)
+    
+    if (nrow(dat) == 0) {
+      warning("The given ", field,"(s) are not in the tcpl database.")
+      return(dat[])
+    }
   }
   
   dat[ , code := NA_character_]
@@ -79,11 +87,11 @@ tcplLoadChem <- function(field = NULL, val = NULL, exact = TRUE,
   dat[ , chid := as.integer(chid)]  
   dat <- unique(dat)
   
-  if (include.spid) return (dat)
+  if (include.spid) return(unique(dat, by = c("spid", "chid")))
   
   dat <- unique(dat[ , list(chid, chnm, casn, code, dsstox_substance_id)])
 
-  dat[]
+  unique(dat, by = c("spid", "chid"))[]
   
 }
 

--- a/R/tcplLoadConcUnit.R
+++ b/R/tcplLoadConcUnit.R
@@ -19,6 +19,13 @@
 
 tcplLoadConcUnit <- function(spid) {
   
+  if (getOption("TCPL_DRVR") == "API") {
+    dat <- tcplQueryAPI(resource = "data", fld = "spid", val = spid, return_flds = c("spid", "tested_conc_unit"))
+    setnames(dat, "tested_conc_unit", "conc_unit")
+    setorder(dat, "spid")
+    return(unique(dat, by = c("spid", "conc_unit")))
+  }
+  
   qformat <- 
     '
     SELECT

--- a/R/tcplLoadUnit.R
+++ b/R/tcplLoadUnit.R
@@ -19,6 +19,13 @@
 
 tcplLoadUnit <- function(aeid) {
   
+  if (getOption("TCPL_DRVR") == "API") {
+    dat <- tcplQueryAPI(resource = "assay", fld = "aeid", val = aeid, return_flds = c("aeid", "normalized_data_type"))
+    setnames(dat, "normalized_data_type", "resp_unit")
+    setorder(dat, "aeid")
+    return(dat)
+  }
+  
   qformat <- 
     "
     SELECT

--- a/R/tcplPrepOtpt.R
+++ b/R/tcplPrepOtpt.R
@@ -98,6 +98,7 @@ tcplPrepOtpt <- function(dat, ids = NULL) {
       if ("casn" %in% dnames) dat[ , casn := NULL]
       if ("chnm" %in% dnames) dat[ , chnm := NULL]
       if ("code" %in% dnames) dat[ , code := NULL]
+      if ("dsstox_substance_id" %in% dnames) dat[ , dsstox_substance_id := NULL]
       cmap <- suppressWarnings(tcplLoadChem("spid", dat[ , unique(spid)]))
       dat <- merge(cmap, dat, by = "spid", all.y = TRUE)
       #add conc units

--- a/R/tcplQueryAPI.R
+++ b/R/tcplQueryAPI.R
@@ -31,7 +31,7 @@ tcplQueryAPI <- function(resource = "data", fld = NULL, val = NULL, return_flds 
     dat <- dat[sapply(dat, nrow) > 0]
     if (lb != length(dat)) warning(paste0("Data not found for the following 'fld' and 'val' combos: \n", paste0(fld, ": ", na_names, collapse = "\n")))
     
-    dat <- rbindlist(dat, use.names=TRUE)
+    dat <- rbindlist(dat, use.names = TRUE, fill = TRUE)
     if (nrow(dat) == 0) return(dat)
     
     dat$dsstox_substance_id <- dat$dtxsid

--- a/R/tcplQueryAPI.R
+++ b/R/tcplQueryAPI.R
@@ -58,9 +58,14 @@ tcplQueryAPI <- function(resource = "data", fld = NULL, val = NULL, return_flds 
                   "' not available. Try using from the following: \n", 
                   paste0(colnames(dat), collapse = "\n")))
     
+    # create index vector to length of field
     fld_indices <- if (length(fld) == 1 | length(fld) == length(val)) 1:length(fld) 
     else stop("'fld' and 'val' must be the same size if length(fld) > 1")
     
+    # put val into a list or move items into first element
+    if (length(fld) == 1) val <- list(unlist(val))
+    
+    # for each field filter by same indexed val
     for (i in fld_indices) {
       dat <- dat[dat[[fld[i]]] %in% val[[i]],]
     }

--- a/R/tcplQueryAPI.R
+++ b/R/tcplQueryAPI.R
@@ -31,7 +31,7 @@ tcplQueryAPI <- function(resource = "data", fld = NULL, val = NULL, return_flds 
     dat <- dat[sapply(dat, nrow) > 0]
     if (lb != length(dat)) warning(paste0("Data not found for the following 'fld' and 'val' combos: \n", paste0(fld, ": ", na_names, collapse = "\n")))
     
-    dat <- rbindlist(dat)
+    dat <- rbindlist(dat, use.names=TRUE)
     if (nrow(dat) == 0) return(dat)
     
     dat$dsstox_substance_id <- dat$dtxsid


### PR DESCRIPTION
Closes #233. Closes #234. Limitation for tcplLoadChem is that only spid can be used as an input.