### PR TITLE
Added sc1 method bval.nwlls.med

### DIFF
--- a/R/sc1_mthds.R
+++ b/R/sc1_mthds.R
@@ -45,6 +45,8 @@
 #'     \item{bval.apid.tn.med}{Calculate the baseline value (bval) as the plate-wise median,
 #'      by assay plate ID (apid), of the raw values (rval) for test compound wells (wllt = t)
 #'       and neutral control wells (wllt = n).}
+#'     \item{bval.nwlls.med}{Calculate the baseline value (bval) as the median of the raw values 
+#'      (rval) for neutral control wells (wllt = n) by assay endpoint id (aeid).}
 #'   }
 #' } 
 #' 

--- a/R/sc1_mthds.R
+++ b/R/sc1_mthds.R
@@ -132,6 +132,14 @@ sc1_mthds <- function() {
       list(e1)
       
     },
+    bval.nwlls.med = function(aeids) {
+
+      e1 <- bquote(dat[J(.(aeids)),
+                       bval := median(rval[wllt == "n"], na.rm = TRUE),
+                       by = list(aeid)])
+      list(e1)
+
+    },
     
     pval.apid.pwlls.med = function(aeids) {
       


### PR DESCRIPTION
Linked to issue [258](https://github.com/USEPA/CompTox-ToxCast-tcpl/issues/258). Added sc1 method to calculate bval using the median across all controls (wllt=='n') by aeid, not by apid.