### PR TITLE
230 update tcpl var mat docs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -60,7 +60,7 @@ Suggests:
     vdiffr
 License: MIT + file LICENSE
 LazyData: true
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.1
 VignetteBuilder: knitr
 Encoding: UTF-8
 Config/testthat/edition: 3

--- a/R/tcplVarMat.R
+++ b/R/tcplVarMat.R
@@ -68,14 +68,18 @@
 #' tcplConf(db = TCPLlite, user = NA, host = NA, drvr = "tcplLite")
 #' \dontrun{
 #' ## Demonstrate the returned values.
-#' tcplVarMat()
+#' varmat <- tcplVarMat()
 #' 
 #' ## Other changes can be made
 #' aeids <- c(80)
 #' dtxsid <- c("DTXSID80379721", "DTXSID10379991", "DTXSID7021106", 
 #' "DTXSID1026081", "DTXSID9032589")
-#' tcplVarMat(aeid = aeids, dsstox_substance_id = dtxsid)
-#' tcplVarMat(aeid = aeids, add.vars = c("m4id", "resp_max", "max_med"))
+#' varmat <- tcplVarMat(aeid = aeids, dsstox_substance_id = dtxsid)
+#' varmat <- tcplVarMat(aeid = aeids, add.vars = c("m4id", "resp_max", "max_med"))
+#' 
+#' ## To save output to file
+#' library(writexl)
+#' write_xlsx(varmat, path = "varmat_output.xlsx")
 #' }
 #' ## Reset configuration
 #' options(conf_store)

--- a/R/tcplVarMat.R
+++ b/R/tcplVarMat.R
@@ -31,15 +31,16 @@
 #' 
 #' \code{tcplVarMat} produces matrices of combined sc-mc output. For the ac50
 #' and acc matrices specifically, values are inserted in place to show complete
-#' views of what was tested and what the results were. ac50 and acc values are
-#' set to:
-#' - 1e6 when the chemical is tested but negative in mc
-#' - 1e7 when the chemical is not tested in mc but was screened in sc with a
+#' views of what was tested and what the results were. ac50 and acc values are:
+#' \itemize{
+#'  \item set to 1e6 when the chemical is tested but negative in mc
+#'  \item set to 1e7 when the chemical is not tested in mc but was screened in sc with a
 #' positive hitcall for the same aeid
-#' - 1e7 when the chemical is not tested in mc but was screened in sc with a
+#'  \item set to 1e8 when the chemical is not tested in mc but was screened in sc with a
 #' negative hitcall for the same aeid
-#' - not changed when chemical is tested in MC and positive, or not tested in
+#'  \item not changed when chemical is tested in MC and positive, or not tested in
 #' either mc or sc
+#' } 
 #' 
 #' sc and mc data both are currently required to be included for these 
 #' calculations.
@@ -49,11 +50,9 @@
 #' 
 #' When more than one sample is included for a chemical/assay pair, 
 #' \code{tcplVarMat} aggregates multiple samples to a chemical level call 
-#' utilizing \code{\link{tcplSubsetChid}}. 
-#' 
-#' The tcplVarMat function calls both \code{tcplSubsetChid}. The input
+#' utilizing \code{\link{tcplSubsetChid}}. The input
 #' for the \code{tcplVarMat} 'flag' parameter is passed to the 
-#' \code{tcplSubsetChid} call used to parse down the data to create the 
+#' \code{tcplSubsetChid} call and used to parse down the data to create the 
 #' matrices.
 #' 
 #' @return A list of chemical by assay matrices (data.tables) where the 

--- a/R/tcplVarMat.R
+++ b/R/tcplVarMat.R
@@ -49,7 +49,8 @@
 #' } 
 #' 
 #' sc and mc data both are currently required to be included for these 
-#' calculations.
+#' calculations. As a result, the "API" driver is not currently supported since
+#' it does not return sc data.
 #' 
 #' To add additional matrices, the 'add.vars' parameter can be used to specify
 #' the fields from the mc4 or mc5 tables to create matrices for.

--- a/R/tcplVarMat.R
+++ b/R/tcplVarMat.R
@@ -19,26 +19,32 @@
 #' for different parameters. The standard list of matrices returned includes:
 #' 
 #' \enumerate{
-#'  \item "ac50" -- The AC50 for the winning model. 
+#'  \item "ac50" -- The active concentration at 50% maximal response (ac50) for 
+#'  the winning model.
 #'  \item "ac50_verbose" -- The AC50 for the winning model, with text describing
 #'  some situations.
-#'  \item "acc" -- The ACC for the winning model.
+#'  \item "acc" -- The active concentration at user-defined cutoff for the 
+#'  winning model.
 #'  \item "acc_verbose" -- The ACC for the winning model, with text describing
 #'  some situations.
-#'  \item "mc_hitc" -- The hit-call for the winning model in mc testing.
-#'  \item "sc_hitc" -- The hit-call in sc testing.
+#'  \item "mc_hitc" -- The hit-call for the winning model in 
+#'  multiple-concentration (mc) screening.
+#'  \item "sc_hitc" -- The hit-call in single concentration (sc) screening.
 #' }
 #' 
 #' \code{tcplVarMat} produces matrices of combined sc-mc output. For the ac50
 #' and acc matrices specifically, values are inserted in place to show complete
 #' views of what was tested and what the results were. ac50 and acc values are:
 #' \itemize{
-#'  \item set to 1e6 when the chemical is tested but negative in mc
-#'  \item set to 1e7 when the chemical is not tested in mc but was screened in sc with a
-#' positive hitcall for the same aeid
-#'  \item set to 1e8 when the chemical is not tested in mc but was screened in sc with a
-#' negative hitcall for the same aeid
-#'  \item not changed when chemical is tested in MC and positive, or not tested in
+#'  \item set to 1e6 when the chemical is tested but negative in mc. In _verbose 
+#'  matrices, these are indicated as "MC neg".
+#'  \item set to 1e7 when the chemical is not tested in mc but was screened in 
+#'  sc with a positive hitcall for the same aeid. In _verbose matrices, these 
+#'  are indicated as "SC pos, No MC".
+#'  \item set to 1e8 when the chemical is not tested in mc but was screened in 
+#'  sc with a negative hitcall for the same aeid. In _verbose matrices, these 
+#'  are indicated as "SC neg, No MC"
+#'  \item not changed when chemical is tested in mc and positive, or not tested in
 #' either mc or sc
 #' } 
 #' 
@@ -60,11 +66,6 @@
 #' name) columns and the colnames are given by assay endpoint name (aenm).
 #' 
 #' @examples 
-#' ## Store the current config settings, so they can be reloaded at the end 
-#' ## of the examples
-#' conf_store <- tcplConfList()
-#' TCPLlite <- file.path(system.file(package = "tcpl"), "example")
-#' tcplConf(db = TCPLlite, user = NA, host = NA, drvr = "tcplLite")
 #' \dontrun{
 #' ## Demonstrate the returned values.
 #' varmat <- tcplVarMat()
@@ -80,8 +81,6 @@
 #' library(writexl)
 #' write_xlsx(varmat, path = "varmat_output.xlsx")
 #' }
-#' ## Reset configuration
-#' options(conf_store)
 #' 
 #' @seealso \code{\link{tcplSubsetChid}}
 #' 

--- a/man/tcplVarMat.Rd
+++ b/man/tcplVarMat.Rd
@@ -47,15 +47,16 @@ for different parameters. The standard list of matrices returned includes:
 
 \code{tcplVarMat} produces matrices of combined sc-mc output. For the ac50
 and acc matrices specifically, values are inserted in place to show complete
-views of what was tested and what the results were. ac50 and acc values are
-set to:
-- 1e6 when the chemical is tested but negative in mc
-- 1e7 when the chemical is not tested in mc but was screened in sc with a
+views of what was tested and what the results were. ac50 and acc values are:
+\itemize{
+ \item set to 1e6 when the chemical is tested but negative in mc
+ \item set to 1e7 when the chemical is not tested in mc but was screened in sc with a
 positive hitcall for the same aeid
-- 1e7 when the chemical is not tested in mc but was screened in sc with a
+ \item set to 1e8 when the chemical is not tested in mc but was screened in sc with a
 negative hitcall for the same aeid
-- not changed when chemical is tested in MC and positive, or not tested in
+ \item not changed when chemical is tested in MC and positive, or not tested in
 either mc or sc
+} 
 
 sc and mc data both are currently required to be included for these 
 calculations.
@@ -65,11 +66,9 @@ the fields from the mc4 or mc5 tables to create matrices for.
 
 When more than one sample is included for a chemical/assay pair, 
 \code{tcplVarMat} aggregates multiple samples to a chemical level call 
-utilizing \code{\link{tcplSubsetChid}}. 
-
-The tcplVarMat function calls both \code{tcplSubsetChid}. The input
+utilizing \code{\link{tcplSubsetChid}}. The input
 for the \code{tcplVarMat} 'flag' parameter is passed to the 
-\code{tcplSubsetChid} call used to parse down the data to create the 
+\code{tcplSubsetChid} call and used to parse down the data to create the 
 matrices.
 }
 \examples{

--- a/man/tcplVarMat.Rd
+++ b/man/tcplVarMat.Rd
@@ -80,14 +80,18 @@ TCPLlite <- file.path(system.file(package = "tcpl"), "example")
 tcplConf(db = TCPLlite, user = NA, host = NA, drvr = "tcplLite")
 \dontrun{
 ## Demonstrate the returned values.
-tcplVarMat()
+varmat <- tcplVarMat()
 
 ## Other changes can be made
 aeids <- c(80)
 dtxsid <- c("DTXSID80379721", "DTXSID10379991", "DTXSID7021106", 
 "DTXSID1026081", "DTXSID9032589")
-tcplVarMat(aeid = aeids, dsstox_substance_id = dtxsid)
-tcplVarMat(aeid = aeids, add.vars = c("m4id", "resp_max", "max_med"))
+varmat <- tcplVarMat(aeid = aeids, dsstox_substance_id = dtxsid)
+varmat <- tcplVarMat(aeid = aeids, add.vars = c("m4id", "resp_max", "max_med"))
+
+## To save output to file
+library(writexl)
+write_xlsx(varmat, path = "varmat_output.xlsx")
 }
 ## Reset configuration
 options(conf_store)

--- a/man/tcplVarMat.Rd
+++ b/man/tcplVarMat.Rd
@@ -35,26 +35,32 @@ The \code{tcplVarMat} function is used to create chemical by assay matrices
 for different parameters. The standard list of matrices returned includes:
 
 \enumerate{
- \item "ac50" -- The AC50 for the winning model. 
+ \item "ac50" -- The active concentration at 50% maximal response (ac50) for 
+ the winning model.
  \item "ac50_verbose" -- The AC50 for the winning model, with text describing
  some situations.
- \item "acc" -- The ACC for the winning model.
+ \item "acc" -- The active concentration at user-defined cutoff for the 
+ winning model.
  \item "acc_verbose" -- The ACC for the winning model, with text describing
  some situations.
- \item "mc_hitc" -- The hit-call for the winning model in mc testing.
- \item "sc_hitc" -- The hit-call in sc testing.
+ \item "mc_hitc" -- The hit-call for the winning model in 
+ multiple-concentration (mc) screening.
+ \item "sc_hitc" -- The hit-call in single concentration (sc) screening.
 }
 
 \code{tcplVarMat} produces matrices of combined sc-mc output. For the ac50
 and acc matrices specifically, values are inserted in place to show complete
 views of what was tested and what the results were. ac50 and acc values are:
 \itemize{
- \item set to 1e6 when the chemical is tested but negative in mc
- \item set to 1e7 when the chemical is not tested in mc but was screened in sc with a
-positive hitcall for the same aeid
- \item set to 1e8 when the chemical is not tested in mc but was screened in sc with a
-negative hitcall for the same aeid
- \item not changed when chemical is tested in MC and positive, or not tested in
+ \item set to 1e6 when the chemical is tested but negative in mc. In _verbose 
+ matrices, these are indicated as "MC neg".
+ \item set to 1e7 when the chemical is not tested in mc but was screened in 
+ sc with a positive hitcall for the same aeid. In _verbose matrices, these 
+ are indicated as "SC pos, No MC".
+ \item set to 1e8 when the chemical is not tested in mc but was screened in 
+ sc with a negative hitcall for the same aeid. In _verbose matrices, these 
+ are indicated as "SC neg, No MC"
+ \item not changed when chemical is tested in mc and positive, or not tested in
 either mc or sc
 } 
 
@@ -72,11 +78,6 @@ for the \code{tcplVarMat} 'flag' parameter is passed to the
 matrices.
 }
 \examples{
-## Store the current config settings, so they can be reloaded at the end 
-## of the examples
-conf_store <- tcplConfList()
-TCPLlite <- file.path(system.file(package = "tcpl"), "example")
-tcplConf(db = TCPLlite, user = NA, host = NA, drvr = "tcplLite")
 \dontrun{
 ## Demonstrate the returned values.
 varmat <- tcplVarMat()
@@ -92,8 +93,6 @@ varmat <- tcplVarMat(aeid = aeids, add.vars = c("m4id", "resp_max", "max_med"))
 library(writexl)
 write_xlsx(varmat, path = "varmat_output.xlsx")
 }
-## Reset configuration
-options(conf_store)
 
 }
 \seealso{

--- a/man/tcplVarMat.Rd
+++ b/man/tcplVarMat.Rd
@@ -65,7 +65,8 @@ either mc or sc
 } 
 
 sc and mc data both are currently required to be included for these 
-calculations.
+calculations. As a result, the "API" driver is not currently supported since
+it does not return sc data.
 
 To add additional matrices, the 'add.vars' parameter can be used to specify
 the fields from the mc4 or mc5 tables to create matrices for.


### PR DESCRIPTION
Updated the tcplVarMat docs with an example of how to save the output to a spreadsheet and general text improvements. Closes #230.

I think we may want to tackle the examples using tcplLite separately. Not sure if we'd rather move in the direction of expanding our "example" driver or switching over to "API" driver.