### PR TITLE
Fix tcplPlot bug when compare.val is set and number of plots is greater than 1

### DIFF
--- a/R/tcplPlot.R
+++ b/R/tcplPlot.R
@@ -126,8 +126,15 @@ tcplPlot <- function(dat = NULL, type = "mc", fld = "m4id", val = NULL, compare.
       ncol <- ifelse(!verbose | type == "sc",3,2)
     }
     
-    
-    
+    # Add a condition to check if compare.val is set and the number of plots is greater than 1
+    if (!is.null(compare.val) && nrow(dat) > 1) {
+      if (output == "console") {
+        stop("More than 1 concentration series returned for given field/val combination. Set output to pdf or reduce the number of curves to 1. Current number of curves: ", nrow(dat))
+      }
+      if (output == "pdf" && multi == FALSE) {
+        nrow = ncol = 1
+      }
+    }
     
     if (nrow(dat[compare == FALSE]) == 1) {
       # plot single graph
@@ -1206,7 +1213,7 @@ tcplggplotCompare <- function(dat, compare.dat, lvl = 5, verbose = FALSE, flags 
     yrange[1] <- min(dat$resp_min, dat$coff, yrange[1], unlist(dat$resp), 
                      compare.dat$resp_min, compare.dat$coff, unlist(compare.dat$resp))
     yrange[2] <- max(dat$resp_max, dat$coff, yrange[2], unlist(dat$resp), 
-                     compare.dat$resp_max, compare.dat$coff, unlist(compare.dat$resp))
+                     compare.dat$resp_max, dat$coff, unlist(compare.dat$resp))
   }
   
   check_wllt <- function(data) {

--- a/tests/testthat/test-plotting.R
+++ b/tests/testthat/test-plotting.R
@@ -1,3 +1,32 @@
-test_that("multiplication works", {
-  expect_equal(2 * 2, 4)
+test_that("tcplPlot handles compare.val with multiple plots", {
+  data("mc_test")
+  mocked <- mc_test$plot_multiple_m4id_compare
+  local_mocked_bindings(
+    tcplQuery = function(query, db, tbl) {
+      if (query == "SHOW VARIABLES LIKE 'max_allowed_packet'") mc_test$tcplConfQuery
+      else mocked[query][[1]]
+    }
+  )
+  tcplConf(drvr = "MySQL", db = "invitrodb") # must include both
+  expect_no_error(suppressWarnings(tcplPlot(type = "mc", fld = "m4id", val = mocked$m4id, compare.val = mocked$compare.m4id, output = "pdf", verbose = TRUE, flags = TRUE, multi = TRUE, fileprefix = "temp_tcplPlot")))
+  expect_no_error(suppressWarnings(tcplPlot(type = "mc", fld = "m4id", val = mocked$m4id, compare.val = mocked$compare.m4id, output = "pdf", flags = TRUE, multi = TRUE, fileprefix = "temp_tcplPlot")))
+  fn <- stringr::str_subset(list.files(), "^temp_tcplPlot")
+  expect_length(fn, 1) # exactly one file created
+  file.remove(fn) # clean up
+})
+
+test_that("tcplPlot handles compare.val with multiple plots and type = 'sc'", {
+  data("sc_test")
+  mocked <- sc_test$plot_multiple_s2id_compare
+  local_mocked_bindings(
+    tcplQuery = function(query, db, tbl) {
+      if (query == "SHOW VARIABLES LIKE 'max_allowed_packet'") sc_test$tcplConfQuery
+      else mocked[query][[1]]
+    }
+  )
+  tcplConf(drvr = "MySQL", db = "invitrodb") # must include both
+  expect_no_error(suppressWarnings(tcplPlot(type = "sc", fld = "s2id", val = mocked$s2id, compare.val = mocked$compare.s2id, output = "pdf", verbose = FALSE, flags = TRUE, multi = TRUE, fileprefix = "temp_tcplPlot_sc")))
+  fn <- stringr::str_subset(list.files(), "^temp_tcplPlot_sc")
+  expect_length(fn, 1) # exactly one file created
+  file.remove(fn) # clean up
 })


### PR DESCRIPTION
Fixes #280

Add condition to handle `compare.val` with multiple plots in `tcplPlot` function.

* **R/tcplPlot.R**
  - Add a condition to check if `compare.val` is set and the number of plots is greater than 1.
  - Modify the `if` condition to handle the case when `compare.val` is set and the number of plots is greater than 1.
  - Ensure that the function does not produce an error when `compare.val` is set and the number of plots is greater than 1.

* **tests/testthat/test-plotting.R**
  - Add a test case to check if `tcplPlot` handles the case when `compare.val` is set and the number of plots is greater than 1.
  - Ensure that the test case verifies that the function does not produce an error in this scenario.
  - Add a test case to check if `tcplPlot` handles the case when `compare.val` is set and the number of plots is greater than 1 with `type` set to 'sc'.

