### PR TITLE
309 sc2 pc40

### DIFF
--- a/R/mc6_mthds.R
+++ b/R/mc6_mthds.R
@@ -47,8 +47,7 @@
 #'   \item{noise}{Flag series as noisy if the quality of fit as calculated by the root mean square 
 #'   error (rmse) for the series is greater than the cutoff (coff); \eqn{rmse > coff}{rmse > coff}.}
 #'   \item{border}{Flag series if borderline activity is suspected based on modeled top parameter 
-#'   (top) relative to cutoff (coff); \eqn{|top|<=1.2*coff~or~|top|>=0.8*coff}{|top| <= 1.2(coff) or
-#'    |top| >= 0.8(coff)}.}
+#'   (top) relative to cutoff (coff); \eqn{0.8*coff<=|top|<=1.2*coff}.}
 #'   \item{overfit.hit}{Method not yet updated for tcpl implementation. Flag hit-calls that would 
 #'   get changed after doing the small N correction to the aic values.}
 #'   \item{efficacy.50}{Flag low efficacy hits if series has an active hit call (hitc >= 0.9) and 

--- a/R/sc2_mthds.R
+++ b/R/sc2_mthds.R
@@ -65,6 +65,7 @@
 #'   \item{pc20}{Add a cutoff value of 20. Typically for percent of control data.}
 #'   \item{pc25}{Add a cutoff value of 25. Typically for percent of control data.}
 #'   \item{pc30}{Add a cutoff value of 30. Typically for percent of control data.}
+#'   \item{pc40}{Add a cutoff value of 40. Typically for percent of control data.}
 #'  }
 #' }
 #' 
@@ -249,6 +250,13 @@ sc2_mthds <- function() {
     pc16 = function() {
       
       e1 <- bquote(coff <- c(coff, 16))
+      list(e1)
+      
+    },
+
+    pc40 = function() {
+      
+      e1 <- bquote(coff <- c(coff, 40))
       list(e1)
       
     }

--- a/man/MC6_Methods.Rd
+++ b/man/MC6_Methods.Rd
@@ -51,8 +51,7 @@ available in the package vignette, "Data_processing."
   \item{noise}{Flag series as noisy if the quality of fit as calculated by the root mean square 
   error (rmse) for the series is greater than the cutoff (coff); \eqn{rmse > coff}{rmse > coff}.}
   \item{border}{Flag series if borderline activity is suspected based on modeled top parameter 
-  (top) relative to cutoff (coff); \eqn{|top|<=1.2*coff~or~|top|>=0.8*coff}{|top| <= 1.2(coff) or
-   |top| >= 0.8(coff)}.}
+  (top) relative to cutoff (coff); \eqn{0.8*coff<=|top|<=1.2*coff}.}
   \item{overfit.hit}{Method not yet updated for tcpl implementation. Flag hit-calls that would 
   get changed after doing the small N correction to the aic values.}
   \item{efficacy.50}{Flag low efficacy hits if series has an active hit call (hitc >= 0.9) and 

--- a/man/SC2_Methods.Rd
+++ b/man/SC2_Methods.Rd
@@ -69,6 +69,7 @@ vignette, "Data_processing."
   \item{pc20}{Add a cutoff value of 20. Typically for percent of control data.}
   \item{pc25}{Add a cutoff value of 25. Typically for percent of control data.}
   \item{pc30}{Add a cutoff value of 30. Typically for percent of control data.}
+  \item{pc40}{Add a cutoff value of 40. Typically for percent of control data.}
  }
 }
 

--- a/vignettes/Introduction_Appendices.Rmd
+++ b/vignettes/Introduction_Appendices.Rmd
@@ -2212,8 +2212,7 @@ FlagDescription <- c("Flag series if model directionality is questionable, i.e. 
                      square error $(rmse)$ for the series is greater than the cutoff $(coff)$; 
                      $rmse > coff$",
                      "Flag series if borderline activity is suspected based on modeled top 
-                     parameter $(top)$ relative to cutoff $(coff)$; $|top| <= 1.2 * coff$ or 
-                     $|top|>= 0.8 * coff$.",
+                     parameter $(top)$ relative to cutoff $(coff)$; $0.8 * coff <= |top| <= 1.2 * coff$",
                      "Flag series if the average number of replicates per concentration is less than
                      2; $nrep < 2$.",
                      "Flag series if 4 concentrations or less were tested; $nconc <= 4$.",


### PR DESCRIPTION
Added new pc40 cutoff method and confirmed that sc2 method works for new ERF single conc processing. I also fixed a minor typo Katie/Rachel found describing borderline flag on this branch.