### PR TITLE
327 update actions/upload-artifacts to v4 due to v3 deprecation

### DIFF
--- a/.github/workflows/test-on-PR.yaml
+++ b/.github/workflows/test-on-PR.yaml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Upload test results
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coverage-test-failures
           path: ${{ runner.temp }}/package


### PR DESCRIPTION
Plotting PR failed to run actions for test-coverage due to deprecation of actions/upload-artifacts: v3. Update here to v4 and will rebase dev into other PRs to pass checks.

https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

Closes #327.