### PR TITLE
updated nmed_gtbl_neg and _pos to use length of unique concs with TRUE

### DIFF
--- a/R/tcplFit2.R
+++ b/R/tcplFit2.R
@@ -29,8 +29,8 @@ tcplFit2 <- function(dat,
     min_med = min(rmds), min_med_conc = conc[which.min(rmds)],
     conc_max = max(conc), conc_min = min(conc), nconc = length(unique(conc)),
     npts = .N, nrep = median(as.numeric(nconcs)), 
-    nmed_gtbl_pos = sum(med_rmds_pos) / first(nconcs), 
-    nmed_gtbl_neg = sum(med_rmds_neg) / first(nconcs),
+    nmed_gtbl_pos = lu(conc[med_rmds_pos]), 
+    nmed_gtbl_neg = lu(conc[med_rmds_neg]),
     concentration_unlogged = list(conc), response = list(resp), m3ids = list(m3id)
   ),
   keyby = .(aeid, spid)


### PR DESCRIPTION
This solution should work to resolve the issue with nmed_gtbl_neg and _pos and consequently fix the issue @Kelly-Carstens-EPA spotted with flagging "active with only highest conc above baseline" and other flags that may use this . Closes #339. Aeid 2940 mc4 column nmed_gtbl_neg before and after update:
![image](https://github.com/user-attachments/assets/fb5c8dfc-1d59-4c80-8c97-31e271483ea2)
![image](https://github.com/user-attachments/assets/08b3d310-1619-40a2-9e1f-978dcb696130)
You can see the very bottom one in each picture is the row with example from https://github.com/USEPA/ToxCast-Internal/issues/127 . Before the issue was it was rounded down to 1 when it should have been 2.